### PR TITLE
Improve styling of docs

### DIFF
--- a/css-stylesheets/supported-css.md
+++ b/css-stylesheets/supported-css.md
@@ -14,7 +14,9 @@ Unless otherwise stated, the following values are supported:
 
 <span class="smallblock">FONT-SIZE</span>: px, pc, pt, em, rem, ex, %, small, medium, large, x-small, x-large  are supported. Default if no unit given is px.
 
-<div class="alert alert-info" role="alert">**Note:** Support for "rem" was added mPDF 5.7  Unlike the CSS3 specification, the basic size used for rem in the document is based on the font-size set on the &lt;body&gt; element (rather than the &lt;html&gt; element).</div>
+<div class="alert alert-info" role="alert" markdown="1">
+**Note:** Support for "rem" was added mPDF 5.7  Unlike the CSS3 specification, the basic size used for rem in the document is based on the font-size set on the <body> element (rather than the <html> element).
+</div>
 
 Conversion from "px" is determined by the configurable variables <a href="{{ "/reference/mpdf-variables/dpi.html" | prepend: site.baseurl }}">dpi</a> and <a href="{{ "/reference/mpdf-variables/img-dpi.html" | prepend: site.baseurl }}">img_dpi</a>
 
@@ -26,90 +28,91 @@ Conversion from "px" is determined by the configurable variables <a href="{{ "/r
 
 Also supported are:
 
-<ul>
-<li>rgb(255,255,255)</li>
-<li>rgba(255,255,255,1) *[last value is transparency (alpha) - between 0-1]**</li>
-<li>rgb(100%,100%,100%)</li>
-<li>hsl(360,100%,100%)</li>
-<li>hsla(360,100%,100%,1) *[last value is transparency (alpha) - between 0-1]**</li>
-<li>cmyk(100,100,100,100) *[or 0-100%]*</li>
-<li>cmyka(100,100,100,100,1) *[or 0-100%; last value is transparency (alpha) - between 0-1]**</li>
-<li>device-cmyk(100,100,100,100) *[or 0-100%]*</li>
-<li>*device-cmyka*(100,100,100,100,1) *[or 0-100%; last value is transparency (alpha) - between 0-1]**</li>
-<li>spot(COLOR NAME, 100%). (cf. <a href="{{ "/reference/mpdf-functions/addspotcolor.html" | prepend: site.baseurl }}">AddSpotColor</a>)</li>
-</ul>
+ * rgb(255,255,255)
+ * rgba(255,255,255,1) *[last value is transparency (alpha) - between 0-1]* *
+ * rgb(100%,100%,100%)
+ * hsl(360,100%,100%)
+ * hsla(360,100%,100%,1) *[last value is transparency (alpha) - between 0-1]* *
+ * cmyk(100,100,100,100) *[or 0-100%]*
+ * cmyka(100,100,100,100,1) *[or 0-100%; last value is transparency (alpha) - between 0-1]* *
+ * device-cmyk(100,100,100,100) *[or 0-100%]*
+ * *device-cmyka*(100,100,100,100,1) *[or 0-100%; last value is transparency (alpha) - between 0-1]* *
+ * spot(COLOR NAME, 100%). (cf. <a href="{{ "/reference/mpdf-functions/addspotcolor.html" | prepend: site.baseurl }}">AddSpotColor</a>)
+
 
 mPDF  >= 5.7 Spotcolor CMYK values can be defined as it is used e.g. color: spot(PANTONE 534 EC, 100%, 85, 65, 47, 9);
 
 *Alpha values (transparency) are only supported on background colours - not text color
 
 <table class="table"> <thead>
-<tr> <th>HTML Tag</th>
-<td>Property</td>
-<td>Values allowed &amp; Notes
-
-</td>
+<tr>
+    <th>HTML Tag</th>
+    <td>Property         </td>
+    <td>Values allowed &amp; Notes</td>
 </tr>
 </thead> <tbody>
-<tr> <th rowspan="9">BODY</th>
-<td>direction
-
+<tr>
+    <th rowspan="9">BODY</th>
+    <td>direction</td>
+    <td>rtl | ltr (mPDF >= 5.0)</td>
+</tr>
+<tr>
+    <td>
+        <span class="smallblock">COMMON TEXT STYLES</span>
+    </td>
+    <td>
+        <span class="smallblock">See <a href="#common-text-styles">below</a> - all except text-shadow</span>
+    </td>
+</tr>
+<tr>
+<td markdown="1">
+*margin-collapse*
 </td>
-<td>rtl | ltr (mPDF >= 5.0)</td>
+    <td>collapse | none (custom attribute - collapses top and bottom margins if at top or bottom of page)</td>
 </tr>
 <tr>
-<td><span class="smallblock">COMMON TEXT STYLES</span>
+    <td>line-height</td>
+<td markdown="1">
+Line height as a factor of font-height. Usual values around 1.2 or 1.3
 
+Also accepts px, pc, pt, cm, mm, in, em and % (mPDF >= 4.0)
 </td>
-<td><span class="smallblock">See below - all except text-shadow
-
-</span></td>
 </tr>
 <tr>
-<td>*margin-collapse*</td>
-<td>collapse | none (custom attribute - collapses top and bottom margins if at top or bottom of page)</td>
-</tr>
-<tr>
-<td>line-height</td>
-<td>Line height as a factor of font-height. Usual values around 1.2 or 1.3
-
-Also accepts px, pc, pt, cm, mm, in, em and % (mPDF >= 4.0)</td>
-</tr>
-<tr>
-<td>background, background-image, background-position, background-repeat, background-color</td>
-<td>
-
+    <td>background, background-image, background-position, background-repeat, background-color</td>
+<td markdown="1">
 background is parsed as per the CSS specification.
 
 background-image in the form url(image.png) or url('image.png') or <span class="smallblock">GRADIENT</span> (mPDF >= 5.1).
 
 background-position is supported as per CSS2.1
 
-background-repeat: repeat | repeat-x | repeat-y | no-repeat
+background-repeat: repeat \| repeat-x \| repeat-y \| no-repeat
 
 background-attachment is parsed but has no effect.
 
 See note below. (cf. <a href="{{ "/what-else-can-i-do/backgrounds-borders.html" | prepend: site.baseurl }}">Backgrounds &amp; borders</a>)
 
 (All except background-color added mPDF 3.0)
-
 </td>
 </tr>
 <tr>
-<td>*background-image-resolution*</td>
-<td>
+<td markdown="1">
+*background-image-resolution*
+</td>
+<td markdown="1">
 
-normal | [ from-image
-
- &lt;dpi&gt; ]  (mPDF >= 5.1)
+normal \| [ from-image \<dpi\> ]  (mPDF >= 5.1)
 
 Custom tag, but as for image-resolution in CSS3
 
 </td>
 </tr>
 <tr>
-<td>*background-gradient*</td>
-<td>
+<td markdown="1">
+*background-gradient*
+</td>
+<td markdown="1">
 
 Defines a linear or radial colour gradient for the background.
 
@@ -124,8 +127,10 @@ x, y and radius are values between 0 and 1
 </td>
 </tr>
 <tr>
-<td>*background-image-opacity*</td>
-<td>
+<td markdown="1">
+*background-image-opacity*
+</td>
+<td markdown="1">
 
 Value between 0 and 1.0
 
@@ -134,8 +139,11 @@ Sets the opacity/transparency of the background image.
 </td>
 </tr>
 <tr>
-<td>*background-image-resize*</td>
-<td>0 - No resizing (default)
+<td markdown="1">
+*background-image-resize*
+</td>
+<td markdown="1">
+0 - No resizing (default)
 
 1 - Shrink-to-fit w (keep aspect ratio)
 
@@ -147,57 +155,39 @@ Sets the opacity/transparency of the background image.
 
 5 - Resize-to-fit h (keep aspect ratio)
 
-6 - Resize-to-fit w and h</td>
-</tr>
-<tr> <th rowspan="30">
-
-All Block level tags:
-
-P, DIV, H1-H6, OL, UL, ADDRESS,
-
-BLOCKQUOTE, CAPTION,
-
-CENTER, DL, DT, DD, FORM,
-
-ARTICLE, ASIDE, DETAILS,
-
-FIELDSET, FIGURE,
-
-FIGCAPTION, FOOTER,
-
-HEADER, HGROUP, NAV,
-
-SECTION, SUMMARY
-
-</th>
-<td>margin*, margin-top, margin-bottom, margin-left, margin-right</td>
-<td>
-
-<span class="smallblock">LENGTH</span>
-
+6 - Resize-to-fit w and h
 </td>
 </tr>
-<tr>
-<td>padding*, padding-right, padding-left, padding-top, padding-bottom</td>
-<td>
-
-<span class="smallblock">LENGTH</span>
-
-</td>
+<tr> 
+    <th rowspan="30">
+        All Block level tags:
+        P, DIV, H1-H6, OL, UL, ADDRESS,
+        BLOCKQUOTE, CAPTION,
+        CENTER, DL, DT, DD, FORM,
+        ARTICLE, ASIDE, DETAILS,
+        FIELDSET, FIGURE,
+        FIGCAPTION, FOOTER,
+        HEADER, HGROUP, NAV,
+        SECTION, SUMMARY
+    </th>
+    <td>margin*, margin-top, margin-bottom, margin-left, margin-right</td>
+    <td><span class="smallblock">LENGTH</span></td>
 </tr>
 <tr>
-<td>border, border-top, border-bottom, border-left, border-right</td>
-<td>
-
+    <td>padding*, padding-right, padding-left, padding-top, padding-bottom</td>
+    <td><span class="smallblock">LENGTH</span></td>
+</tr>
+<tr>
+    <td>border, border-top, border-bottom, border-left, border-right</td>
+<td markdown="1">
 Size style and colour e.g.
 
-<span class="smallblock">LENGTH</span> solid|dotted|dashed|double <span class="smallblock">COLOR</span>
-
+<span class="smallblock">LENGTH</span> solid|dotted|dashed|double <span class="smallblock">COLOR</span>
 </td>
 </tr>
 <tr>
-<td>border-color*, border-top-color, border-right-color, border-bottom-color, border-left-color</td>
-<td>
+    <td>border-color*, border-top-color, border-right-color, border-bottom-color, border-left-color</td>
+<td markdown="1">
 
 <span class="smallblock">COLOR</span>
 
@@ -206,18 +196,19 @@ Size style and colour e.g.
 </td>
 </tr>
 <tr>
-<td>border-width*, border-top-width, border-right-width, border-bottom-width, border-left-width</td>
-<td>
+    <td>border-width*, border-top-width, border-right-width, border-bottom-width, border-left-width</td>
+<td markdown="1">
 
 <span class="smallblock">LENGTH</span> 
 
-(mPDF >= 4.0)</td>
+(mPDF >= 4.0)
+</td>
 </tr>
 <tr>
-<td>border-style*, border-top-style, border-right-style, border-bottom-style, border-left-style</td>
-<td>
+    <td>border-style*, border-top-style, border-right-style, border-bottom-style, border-left-style</td>
+<td markdown="1">
 
-solid|dotted|dashed|double
+solid \| dotted \| dashed \| double
 
 (mPDF >= 4.0)
 
@@ -226,16 +217,18 @@ solid|dotted|dashed|double
 </td>
 </tr>
 <tr>
-<td>border-radius, border-top-left-radius, border-top-right-radius, border-bottom-right-radius, border-bottom-left-radius</td>
-<td><span class="smallblock">LENGTH</span>
+    <td>border-radius, border-top-left-radius, border-top-right-radius, border-bottom-right-radius, border-bottom-left-radius</td>
+<td markdown="1">
+<span class="smallblock">LENGTH</span>
 
 See <a href="http://www.w3.org/TR/2008/WD-css3-background-20080910/#layering">draft CSS3 specification</a> for use.
 
-NB Use of $autoPadding which can automatically increase padding in block elements with border-radius set as required</td>
+NB Use of $autoPadding which can automatically increase padding in block elements with border-radius set as required
+</td>
 </tr>
 <tr>
-<td>width</td>
-<td>
+    <td>width</td>
+<td markdown="1">
 
 <span class="smallblock">LENGTH</span>
 
@@ -244,8 +237,8 @@ mPDF does not support nested block elements which overlap (horizontally or verti
 </td>
 </tr>
 <tr>
-<td>height</td>
-<td>
+    <td>height</td>
+<td markdown="1">
 
 <span class="smallblock">LENGTH</span> 
 
@@ -258,40 +251,40 @@ NB % is interpreted as % of printable page height (inside margins)
 </td>
 </tr>
 <tr>
-<td>text-align</td>
-<td>left | center | right | justify</td>
+    <td>text-align</td>
+    <td>left | center | right | justify</td>
 </tr>
 <tr>
-<td>page-break-after</td>
-<td>auto | avoid | always | left | right (extended mPDF >= 5.4)
-
+    <td>page-break-after</td>
+    <td>auto | avoid | always | left | right (extended mPDF >= 5.4)</td>
+</tr>
+<tr>
+    <td>page-break-inside</td>
+    <td>avoid (avoids a page-break within the block - only works across max. of 2 pages; not compatible with table autosize or table rotate)</td>
+</tr>
+<tr>
+    <td>page-break-before</td>
+    <td>always | left | right</td>
+</tr>
+<tr>
+    <td>display</td>
+    <td>none</td>
+</tr>
+<tr>
+    <td>visibility</td>
+<td markdown="1">
+visible \| hidden \| *printonly* \| *screenonly*  (mPDF >= 5.4)
 </td>
 </tr>
 <tr>
-<td>page-break-inside</td>
-<td>avoid (avoids a page-break within the block - only works across max. of 2 pages; not compatible with table autosize or table rotate)</td>
-</tr>
-<tr>
-<td>page-break-before</td>
-<td>always | left | right</td>
-</tr>
-<tr>
-<td>display</td>
-<td>none</td>
-</tr>
-<tr>
-<td>visibility</td>
-<td>visible | hidden | *printonly* | *screenonly*  (mPDF >= 5.4)
-
+<td markdown="1">
+*margin-collapse*
 </td>
+    <td>collapse | none (custom attribute - collapses top and bottom margins if at top or bottom of page)</td>
 </tr>
 <tr>
-<td>*margin-collapse*</td>
-<td>collapse|none (custom attribute - collapses top and bottom margins if at top or bottom of page)</td>
-</tr>
-<tr>
-<td>line-height</td>
-<td>
+    <td>line-height</td>
+<td markdown="1">
 
 Line height as a factor of font-height. Usual values around 1.2 or 1.3
 
@@ -302,10 +295,10 @@ Also accepts px, pc, pt, cm, mm, in, em and % (mPDF >= 4.0)
 </td>
 </tr>
 <tr>
-<td>line-stacking-strategy</td>
-<td>
+    <td>line-stacking-strategy</td>
+<td markdown="1">
 
-inline-line-height | block-line-height | max-height | grid-height
+inline-line-height \| block-line-height \| max-height \| grid-height
 
 As per draft CSS3 spec. (mPDF >= 6.0)
 
@@ -314,10 +307,10 @@ Default = inline-line-height
 </td>
 </tr>
 <tr>
-<td>line-stacking-shift</td>
-<td>
+    <td>line-stacking-shift</td>
+<td markdown="1">
 
-consider-shifts | disregard-shifts
+consider-shifts \| disregard-shifts
 
 As per draft CSS3 spec. (mPDF >= 6.0)
 
@@ -326,8 +319,8 @@ Default = consider-shifts
 </td>
 </tr>
 <tr>
-<td>background, background-image, background-position, background-repeat, background-color</td>
-<td>
+    <td>background, background-image, background-position, background-repeat, background-color</td>
+<td markdown="1">
 
 background is parsed as per the CSS specification.
 
@@ -335,7 +328,7 @@ background-image in the form url(image.png) or url('image.png') or <span class="
 
 background-position is supported as per CSS2.1
 
-background-repeat: repeat | repeat-x | repeat-y | no-repeat
+background-repeat: repeat \| repeat-x \| repeat-y \| no-repeat
 
 background-attachment is parsed but has no effect.
 
@@ -346,50 +339,52 @@ See note below. (cf. <a href="{{ "/what-else-can-i-do/backgrounds-borders.html" 
 </td>
 </tr>
 <tr>
-<td>background-clip</td>
-<td>
+    <td>background-clip</td>
+<td markdown="1">
 
-padding-box|border-box (default=border-box)
+padding-box \| border-box (default=border-box)
 
 extended to include "content-box" from mPDF 5.7
 
 </td>
 </tr>
 <tr>
-<td>background-origin</td>
-<td>
+    <td>background-origin</td>
+<td markdown="1">
 
-padding-box|content-box|border-box  (default padding-box)
-
-As per CSS3. mPDF >= 5.7
-
-</td>
-</tr>
-<tr>
-<td>background-size</td>
-<td>
-
-[ &lt;length&gt; | &lt;percentage&gt; | auto ]{1,2} | cover | contain  (default = auto)
+padding-box \| content-box \| border-box  (default padding-box)
 
 As per CSS3. mPDF >= 5.7
 
 </td>
 </tr>
 <tr>
-<td>*background-image-resolution*</td>
-<td>
+    <td>background-size</td>
+<td markdown="1">
 
-normal | [ from-image
+[ \<length\> \| \<percentage\> \| auto ]{1,2} \| cover \| contain  (default = auto)
 
- &lt;dpi&gt; ]  (mPDF >= 5.1)
+As per CSS3. mPDF >= 5.7
+
+</td>
+</tr>
+<tr>
+<td markdown="1">
+*background-image-resolution*
+</td>
+<td markdown="1">
+
+normal \| [ from-image \<dpi\> ]  (mPDF >= 5.1)
 
 Custom tag, but as for image-resolution in CSS3
 
 </td>
 </tr>
 <tr>
-<td>*background-gradient*</td>
-<td>
+<td markdown="1">
+*background-gradient*
+</td>
+<td markdown="1">
 
 Defines a linear or radial colour gradient for the background.
 
@@ -404,8 +399,10 @@ x, y and radius are values between 0 and 1
 </td>
 </tr>
 <tr>
-<td>*background-image-opacity*</td>
-<td>
+<td markdown="1">
+*background-image-opacity*
+</td>
+<td markdown="1">
 
 Value between 0 and 1.0
 
@@ -414,8 +411,11 @@ Sets the opacity/transparency of the background image.
 </td>
 </tr>
 <tr>
-<td>*background-image-resize*</td>
-<td>0 - No resizing (default)
+<td markdown="1">
+*background-image-resize*
+</td>
+<td markdown="1">
+0 - No resizing (default)
 
 1 - Shrink-to-fit w (keep aspect ratio)
 
@@ -427,15 +427,12 @@ Sets the opacity/transparency of the background image.
 
 5 - Resize-to-fit h (keep aspect ratio)
 
-6 - Resize-to-fit w and h</td>
+6 - Resize-to-fit w and h
+</td>
 </tr>
 <tr>
-<td>
-
-box-shadow
-
-</td>
-<td>
+    <td>box-shadow</td>
+<td markdown="1">
 
 As per CSS3 specification. 'inset' is not supported.
 
@@ -444,18 +441,18 @@ As per CSS3 specification. 'inset' is not supported.
 </td>
 </tr>
 <tr>
-<td>box-decoration-break</td>
-<td>
+    <td>box-decoration-break</td>
+<td markdown="1">
 
-slice | clone  (default = slice)
+slice \| clone  (default = slice)
 
 Defines the handling of padding and borders at page breaks, when <a href="{{ "/paging/page-breaks.html" | prepend: site.baseurl }}">clonebycss</a> set
 
 </td>
 </tr>
 <tr>
-<td>z-index</td>
-<td>
+    <td>z-index</td>
+<td markdown="1">
 
 Sets a layer in the PDF document.
 
@@ -463,37 +460,27 @@ Note: this is not the same as a "layer" in CSS terms. See <a href="{{ "/what-els
 
 </td>
 </tr>
-<tr> <th rowspan="11">
+<tr> 
+    <th rowspan="11">
+        All Block level tags:
+        P, DIV, H1-H6, OL, UL, ADDRESS,
+        BLOCKQUOTE, CAPTION,
+        CENTER, DL, DT, DD, FORM,
+        ARTICLE, ASIDE, DETAILS,
+        FIELDSET, FIGURE, FIGCAPTION, FOOTER,
+        HEADER, HGROUP, NAV,
+        SECTION, SUMMARY
 
-All Block level tags:
-
-P, DIV, H1-H6, OL, UL, ADDRESS,
-
-BLOCKQUOTE, CAPTION,
-
-CENTER, DL, DT, DD, FORM,
-
-ARTICLE, ASIDE, DETAILS,
-
-FIELDSET, FIGURE, FIGCAPTION, FOOTER,
-
-HEADER, HGROUP, NAV,
-
-SECTION, SUMMARY
-
-(contd.)
-
-</th>
-<td><span class="smallblock">COMMON TEXT STYLES</span></td>
-<td><span class="smallblock">See below</span></td>
+        (contd.)
+    </th>
+    <td><span class="smallblock">COMMON TEXT STYLES</span></td>
+    <td><span class="smallblock">See <a href="#common-text-styles">below</a></span></td>
 </tr>
 <tr>
-<td>
-
+<td markdown="1">
 *text-indent*
-
 </td>
-<td>
+<td markdown="1">
 
 Indents first line of text in the paragraph/block.
 
@@ -506,8 +493,9 @@ Negative value will give a 'hanging indent'.
 </td>
 </tr>
 <tr>
-<td>position</td>
-<td>fixed | absolute
+    <td>position</td>
+<td markdown="1">
+fixed \| absolute
 
 absolute - uses physical page as containing element;
 
@@ -515,15 +503,15 @@ fixed - uses printable page (inside margins) as containing element.
 
 (mPDF >= 4.0)
 
-NB Only supported for top-level elements i.e. where the parent element is &lt;body&gt;. Fixed-position or floating elements nested inside other fixed-position or floating elements are not supported.
+NB Only supported for top-level elements i.e. where the parent element is <body>. Fixed-position or floating elements nested inside other fixed-position or floating elements are not supported.
 
 </td>
 </tr>
 <tr>
-<td>overflow</td>
-<td>
+    <td>overflow</td>
+<td markdown="1">
 
-visible | hidden | auto
+visible \| hidden \| auto
 
 Applies to block elements with position fixed or absolute. auto - causes text to autofit within the block size (constrained if necessary to page edges).
 
@@ -532,20 +520,22 @@ Applies to block elements with position fixed or absolute. auto - causes text to
 </td>
 </tr>
 <tr>
-<td>hyphens</td>
-<td>
+    <td>hyphens</td>
+<td markdown="1">
 
-none | manual | auto (default = manual)
+none \| manual \| auto (default = manual)
 
 As per CSS. (mPDF  >= 5.7)
 
 </td>
 </tr>
 <tr>
-<td>*rotate*</td>
-<td>
+<td markdown="1">
+*rotate*
+</td>
+<td markdown="1">
 
-90 | -90
+90 \| -90
 
 Applies only to block elements with position fixed or absolute. (mPDF >= 5.0)
 
@@ -554,8 +544,8 @@ Sizing and layout of the block element using top, left, bottom, right, width and
 </td>
 </tr>
 <tr>
-<td>top, left, bottom, right</td>
-<td>
+    <td>top, left, bottom, right</td>
+<td markdown="1">
 
 <span class="smallblock">LENGTH</span>
 
@@ -566,10 +556,10 @@ Applies to block elements with position fixed or absolute.
 </td>
 </tr>
 <tr>
-<td>float</td>
-<td>
+    <td>float</td>
+<td markdown="1">
 
-left|right
+left \| right
 
 Partially supported as for CSS2 property.
 
@@ -578,47 +568,40 @@ NB Fixed-position or floating elements nested inside other fixed-position or flo
 </td>
 </tr>
 <tr>
-<td>clear</td>
-<td>left|right|both</td>
+    <td>clear</td>
+    <td>left | right | both</td>
 </tr>
 <tr>
-<td>page</td>
-<td>Specify a named page selector (see @page)</td>
+    <td>page</td>
+    <td>Specify a named page selector (see @page)</td>
 </tr>
 <tr>
-<td>direction</td>
-<td>rtl | ltr (mPDF >= 5.1)</td>
+    <td>direction</td>
+    <td>rtl | ltr (mPDF >= 5.1)</td>
 </tr>
 </tbody> </table>
-<table class="table"> <thead>
-<tr> <th>HTML Tag</th>
-<td>Property</td>
-<td>Values allowed &amp; Notes
 
-</td>
+
+
+<table class="table"> <thead>
+<tr> 
+    <th>HTML Tag</th>
+    <td>Property     </td>
+    <td>Values allowed &amp; Notes</td>
 </tr>
 </thead> <tbody>
-<tr> <th rowspan="5">
-
-LIST tags: OL, UL
-
-</th>
-<td>list-style</td>
-<td>[ 'list-style-type'
-
- 'list-style-position'
-
- 'list-style-image' ]   mPDF >= 6.0</td>
+<tr> 
+    <th rowspan="5">LIST tags: OL, UL</th>
+    <td>list-style</td>
+    <td>[ 'list-style-type' 'list-style-position' 'list-style-image' ]   mPDF >= 6.0</td>
 </tr>
 <tr>
-<td>list-style-type* *</td>
-<td>
-<ul> </li>
-</ul>
+    <td>list-style-type* *</td>
+<td markdown="1">
 
-1 | A | a | I | i | disc | circle | square | decimal | lower-roman | upper-roman | lower-latin | upper-latin | lower-alpha | upper-alpha | none
+1 \| A \| a \| I \| i \| disc \| circle \| square \| decimal \| lower-roman \| upper-roman \| lower-latin \| upper-latin \| lower-alpha \| upper-alpha \| none
 
-arabic-indic | bengali | cambodian | cjk-decimal | devanagari | gujarati | gurmukhi | hebrew |kannada | khmer | lao | malayalam | oriya | persian | telugu | thai | urdu | tamil
+arabic-indic \| bengali \| cambodian \| cjk-decimal \| devanagari \| gujarati \| gurmukhi \| hebrew \|kannada \| khmer \| lao \| malayalam \| oriya \| persian \| telugu \| thai \| urdu \| tamil
 
 "1" - decimal
 
@@ -631,62 +614,54 @@ arabic-indic | bengali | cambodian | cjk-decimal | devanagari | gujarati | gurmu
 "i" = lower-roman
 
 Custom list-style-type is recognised e.g.: U+263Argb(255,0,0);
-
 - where U+263A is the Unicode HEX value of the character you want for the bullet
-
 - the character MUST be included in the font used for that list item
-
 - rgb() bit is optional
 
 </td>
 </tr>
 <tr>
-<td>list-style-image</td>
-<td>
+    <td>list-style-image</td>
+<td markdown="1">
 
-<span class="smallblock">&lt;URI&gt;</span>
-
-mPDF >= 6.0
-
-</td>
-</tr>
-<tr>
-<td>list-style-position</td>
-<td>
-
-inside | outside  (default = outside)
+<span class="smallblock" markdown="1">&lt;URI&gt;</span>
 
 mPDF >= 6.0
 
 </td>
 </tr>
 <tr>
-<td> </td>
-<td>**NB Lists are handled as block-level elements as from mPDF 6.0 (see above)**</td>
-</tr>
-<tr> <th rowspan="5">
+    <td>list-style-position</td>
+<td markdown="1">
 
-LI
+inside \| outside  (default = outside)
 
-</th>
-<td>list-style</td>
-<td>
-
-[ 'list-style-type'
-
- 'list-style-position'
-
- 'list-style-image' ]   mPDF >= 6.0
+mPDF >= 6.0
 
 </td>
 </tr>
 <tr>
-<td>list-style-type* *</td>
-<td>
+    <td> </td>
+<td markdown="1">
+**NB Lists are handled as block-level elements as from mPDF 6.0 (see above)**
+</td>
+</tr>
+<tr> 
+    <th rowspan="5">LI</th>
+    <td>list-style</td>
+<td markdown="1">
+[ 'list-style-type' 'list-style-position' 'list-style-image' ]   
 
-1 | A | a | I | i | disc | circle | square | decimal | lower-roman | upper-roman | lower-latin | upper-latin | lower-alpha | upper-alpha | none
+mPDF >= 6.0
+</td>
+</tr>
+<tr>
+    <td>list-style-type* *</td>
+<td markdown="1">
 
-arabic-indic | bengali | cambodian | cjk-decimal | devanagari | gujarati | gurmukhi | hebrew |kannada | khmer | lao | malayalam | oriya | persian | telugu | thai | urdu | tamil
+1 \| A \| a \| I \| i \| disc \| circle \| square \| decimal \| lower-roman \| upper-roman \| lower-latin \| upper-latin \| lower-alpha \| upper-alpha \| none
+
+arabic-indic \| bengali \| cambodian \| cjk-decimal \| devanagari \| gujarati \| gurmukhi \| hebrew \|kannada \| khmer \| lao \| malayalam \| oriya \| persian \| telugu \| thai \| urdu \| tamil
 
 "1" - decimal
 
@@ -699,87 +674,76 @@ arabic-indic | bengali | cambodian | cjk-decimal | devanagari | gujarati | gurmu
 "i" = lower-roman
 
 Custom list-style-type is recognised e.g.: U+263Argb(255,0,0);
-
 - where U+263A is the Unicode HEX value of the character you want for the bullet
-
 - the character MUST be included in the font used for that list item
-
 - rgb() bit is optional
 
 </td>
 </tr>
 <tr>
-<td>list-style-image</td>
-<td>
+    <td>list-style-image</td>
+<td markdown="1">
 
-<span class="smallblock">&lt;URI&gt;</span>
+<span class="smallblock" markdown="1">&lt;URI&gt;</span>
 
-mPDF >= 6.0</td>
+mPDF >= 6.0
+</td>
 </tr>
 <tr>
-<td>list-style-position</td>
-<td>
+    <td>list-style-position</td>
+<td markdown="1">
 
-inside | outside  (default = outside)
+inside \| outside  (default = outside)
 
 mPDF >= 6.0
 
 </td>
 </tr>
 <tr>
-<td> </td>
-<td>**NB Lists are handled as block-level elements as from mPDF 6.0 (see above)**</td>
-</tr>
-</tbody> </table>
-<table class="table"> <thead>
-<tr> <th>
-
-HTML Tag
-
-</th>
-<td>Property</td>
-<td>Values allowed &amp; Notes
-
+    <td> </td>
+<td markdown="1">
+**NB Lists are handled as block-level elements as from mPDF 6.0 (see above)**
 </td>
 </tr>
+</tbody> </table>
+
+
+
+<table class="table"> <thead>
+<tr> 
+    <th>HTML Tag</th>
+    <td>Property</td>
+    <td>Values allowed &amp; Notes
+
+    </td>
+</tr>
 </thead> <tbody>
-<tr> <th rowspan="9">
-
-All Inline tags:
-
-SPAN, A, SUB, SUP,  ACRONYM,
-
-BIG, SMALL, INS, S, STRIKE,
-
-DEL, STRONG, CITE, Q, EM,
-
-B, I, U, SAMP, CODE, KBD, TT,
-
-VAR, FONT, TIME, MARK
-
-</th>
-<td><span class="smallblock">COMMON TEXT STYLES</span></td>
-<td><span class="smallblock">See below</span></td>
+<tr> 
+    <th rowspan="9">
+        All Inline tags:
+        SPAN, A, SUB, SUP,  ACRONYM,
+        BIG, SMALL, INS, S, STRIKE,
+        DEL, STRONG, CITE, Q, EM,
+        B, I, U, SAMP, CODE, KBD, TT,
+        VAR, FONT, TIME, MARK
+    </th>
+    <td><span class="smallblock">COMMON TEXT STYLES</span></td>
+    <td><span class="smallblock">See <a href="#common-text-styles">below</a></span></td>
 </tr>
 <tr>
-<td>border, border-top, border-bottom, border-left, border-right</td>
-<td>
+    <td>border, border-top, border-bottom, border-left, border-right</td>
+<td markdown="1">
 
 Size style and colour e.g.
 
-<span class="smallblock">LENGTH</span> solid|dotted|dashed|double <span class="smallblock">COLOR</span>
+<span class="smallblock">LENGTH</span> solid\|dotted\|dashed\|double <span class="smallblock">COLOR</span>
 
 (mPDF >= 5.4)
-
 </td>
 </tr>
 <tr>
-<td>
-
-border-color*, border-top-color, border-right-color, border-bottom-color, border-left-color
-
-</td>
-<td>
+    <td>border-color*, border-top-color, border-right-color, border-bottom-color, border-left-color</td>
+<td markdown="1">
 
 <span class="smallblock">COLOR</span>
 
@@ -788,75 +752,74 @@ border-color*, border-top-color, border-right-color, border-bottom-color, border
 </td>
 </tr>
 <tr>
-<td>
-
-border-width*, border-top-width, border-right-width, border-bottom-width, border-left-width
-
-</td>
-<td>
+    <td>border-width*, border-top-width, border-right-width, border-bottom-width, border-left-width</td>
+<td markdown="1">
 
 <span class="smallblock">LENGTH</span> 
 
-(mPDF >= 5.4)</td>
+(mPDF >= 5.4)
+</td>
 </tr>
 <tr>
-<td>
+<td markdown="1">
 
 border-style*, border-top-style, border-right-style, border-bottom-style, border-left-style
 
 </td>
-<td>
+<td markdown="1">
 
-solid|dotted|dashed|double
+solid \| dotted \| dashed \| double
 
 (mPDF >= 5.4)
 
 </td>
 </tr>
 <tr>
-<td>background-color, background</td>
-<td><span class="smallblock">COLOR</span> (only the color is supported in background)
-
-</td>
+    <td>background-color, background</td>
+    <td><span class="smallblock">COLOR</span> (only the color is supported in background)</td>
 </tr>
 <tr>
-<td>display</td>
-<td>none (mPDF >= 5.0)</td>
+    <td>display</td>
+    <td>none (mPDF >= 5.0)</td>
 </tr>
 <tr>
-<td>visibility</td>
-<td>
+    <td>visibility</td>
+<td markdown="1">
 
-hidden | visible | printonly | screenonly (default = visible)
+hidden \| visible \| printonly \| screenonly (default = visible)
 
 (mPDF >= 5.7)
 
 </td>
 </tr>
 <tr>
-<td>hyphens</td>
-<td>
+    <td>hyphens</td>
+<td markdown="1">
 
-none | manual | auto (default = manual)
+none \| manual \| auto (default = manual)
 
-As per CSS. (mPDF  >= 5.7)</td>
-</tr>
-</tbody> </table>
-<table class="table"> <thead>
-<tr> <th style="white-space: nowrap;">HTML Tag</th>
-<td>Property</td>
-<td>Values allowed &amp; Notes
-
+As per CSS. (mPDF  >= 5.7)
 </td>
 </tr>
+</tbody> </table>
+
+
+
+<table class="table"> <thead>
+<tr> 
+    <th style="white-space: nowrap;">HTML Tag</th>
+    <td>Property</td>
+    <td>Values allowed &amp; Notes</td>
+</tr>
 </thead> <tbody>
-<tr> <th rowspan="28">TABLE</th>
-<td>background-color</td>
-<td><span class="smallblock">COLOR</span></td>
+<tr>
+    <th rowspan="28">TABLE</th>
+    <td>background-color</td>
+    <td><span class="smallblock">COLOR</span></td>
 </tr>
 <tr>
-<td>background, background-image, background-position, background-repeat, background-color</td>
-<td>
+    <td>background, background-image, background-position, background-repeat, background-color</td>
+<td markdown="1">
 
 background is parsed as per the CSS specification.
 
@@ -864,7 +827,7 @@ background-image in the form url(image.png) or url('image.png') or <span class="
 
 background-position is supported as per CSS2.1
 
-background-repeat: repeat | repeat-x | repeat-y | no-repeat
+background-repeat: repeat \| repeat-x \| repeat-y \| no-repeat
 
 background-attachment is parsed but has no effect.
 
@@ -875,14 +838,16 @@ See note below. (cf. <a href="{{ "/what-else-can-i-do/backgrounds-borders.html" 
 </td>
 </tr>
 <tr>
-<td>background-image-resolution</td>
-<td>normal | [ from-image
-
- &lt;dpi&gt; ]  (mPDF >= 5.1)</td>
+    <td>background-image-resolution</td>
+<td markdown="1">
+normal \| [ from-image \<dpi\> ]  (mPDF >= 5.1)
+</td>
 </tr>
 <tr>
-<td>*background-image-opacity*</td>
-<td>
+<td markdown="1">
+*background-image-opacity*
+</td>
+<td markdown="1">
 
 Value between 0 and 1.0
 
@@ -891,30 +856,24 @@ Sets the opacity/transparency of the background image.
 </td>
 </tr>
 <tr>
-<td><span class="smallblock">COMMON TEXT STYLES</span></td>
-<td><span class="smallblock">See below - except text-decoration, text-transform and text-shadow
-
-</span></td>
+    <td><span class="smallblock">COMMON TEXT STYLES</span></td>
+    <td><span class="smallblock">See <a href="#common-text-styles">below</a> - except text-decoration, text-transform and text-shadow</span></td>
 </tr>
 <tr>
-<td>
-
-border, border-right, border-left, border-top, border-bottom
-
-</td>
-<td>
+    <td>border, border-right, border-left, border-top, border-bottom</td>
+<td markdown="1">
 
 Size style and colour e.g.
 
-<span class="smallblock">LENGTH</span> double | solid | dashed | dotted | ridge | outset | groove | inset | hidden | none <span class="smallblock">COLOR</span> 
+<span class="smallblock">LENGTH</span> double \| solid \| dashed \| dotted \| ridge \| outset \| groove \| inset \| hidden \| none <span class="smallblock">COLOR</span> 
 
-NB Table &amp; cell borders accept: double | solid | dashed | dotted | ridge | outset | groove | inset (other block elements only support solid | dotted | dashed | double)
+NB Table & cell borders accept: double \| solid \| dashed \| dotted \| ridge \| outset \| groove \| inset (other block elements only support solid \| dotted \| dashed \| double)
 
 </td>
 </tr>
 <tr>
-<td>border-color*, border-top-color, border-right-color, border-bottom-color, border-left-color</td>
-<td>
+    <td>border-color*, border-top-color, border-right-color, border-bottom-color, border-left-color</td>
+<td markdown="1">
 
 <span class="smallblock">COLOR</span>
 
@@ -923,26 +882,27 @@ NB Table &amp; cell borders accept: double | solid | dashed | dotted | ridge | o
 </td>
 </tr>
 <tr>
-<td>border-width*, border-top-width, border-right-width, border-bottom-width, border-left-width</td>
-<td>
+    <td>border-width*, border-top-width, border-right-width, border-bottom-width, border-left-width</td>
+<td markdown="1">
 
 <span class="smallblock">LENGTH</span> 
 
-(mPDF >= 4.0)</td>
+(mPDF >= 4.0)
+</td>
 </tr>
 <tr>
-<td>border-style*, border-top-style, border-right-style, border-bottom-style, border-left-style</td>
-<td>
+    <td>border-style*, border-top-style, border-right-style, border-bottom-style, border-left-style</td>
+<td markdown="1">
 
-double | solid | dashed | dotted | ridge | outset | groove | inset | hidden | none
+double \| solid \| dashed \| dotted \| ridge \| outset \| groove \| inset \| hidden \| none
 
 (mPDF >= 4.0)
 
 </td>
 </tr>
 <tr>
-<td>padding*, padding-right, padding-left, padding-top, padding-bottom</td>
-<td>
+    <td>padding*, padding-right, padding-left, padding-top, padding-bottom</td>
+<td markdown="1">
 
 <span class="smallblock">LENGTH</span>
 
@@ -953,28 +913,28 @@ Sets table padding (only relevant when border-collapse:separate)
 </td>
 </tr>
 <tr>
-<td>margin*, margin-right, margin-left, margin-top, margin-bottom</td>
-<td><span class="smallblock">LENGTH</span></td>
+    <td>margin*, margin-right, margin-left, margin-top, margin-bottom</td>
+    <td><span class="smallblock">LENGTH</span></td>
 </tr>
 <tr>
-<td>width</td>
-<td><span class="smallblock">LENGTH</span></td>
+    <td>width</td>
+    <td><span class="smallblock">LENGTH</span></td>
 </tr>
 <tr>
-<td>vertical-align</td>
-<td>top | middle | bottom (applies to all cells in table)</td>
+    <td>vertical-align</td>
+    <td>top | middle | bottom (applies to all cells in table)</td>
 </tr>
 <tr>
-<td>text-align</td>
-<td>left | right | center (applies to all cells in table; to centre a table on the page, you must use the align="center" attribute in the table tag)</td>
+    <td>text-align</td>
+    <td>left | right | center (applies to all cells in table; to centre a table on the page, you must use the align="center" attribute in the table tag)</td>
 </tr>
 <tr>
-<td>border-collapse</td>
-<td>collapse | separate</td>
+    <td>border-collapse</td>
+    <td>collapse | separate</td>
 </tr>
 <tr>
-<td>border-spacing</td>
-<td>
+    <td>border-spacing</td>
+<td markdown="1">
 
 Single or double values:
 
@@ -987,95 +947,109 @@ Single or double values:
 </td>
 </tr>
 <tr>
-<td>empty-cells</td>
-<td>hide | show (only relevant when border-collapse:separate)</td>
+    <td>empty-cells</td>
+    <td>hide | show (only relevant when border-collapse:separate)</td>
 </tr>
 <tr>
-<td>page-break-inside</td>
-<td>avoid</td>
+    <td>page-break-inside</td>
+    <td>avoid</td>
 </tr>
 <tr>
-<td>page-break-after</td>
-<td>left | right | always
+    <td>page-break-after</td>
+<td markdown="1">
+left \| right \| always
 
-(mPDF >= 5.4)</td>
-</tr>
-<tr>
-<td>*rotate*</td>
-<td>rotates the table 90 degress clockwise (90) or counter-clockwise (-90). Does not work with columns, and bookmarks will not be correctly placed (custom attribute)</td>
-</tr>
-<tr>
-<td>*autosize*</td>
-<td>Shrinks a table to fit if width is too small to allow complete words to fit. The value (must be >=1) determines the maximum allowable factor to shrink i.e. autosize="2" will allow the font-size to be reduced to a minimum of 1/2 the original size. A value of 1 prevents automatic resizing of the table. (custom property)</td>
-</tr>
-<tr>
-<td>*topntail*</td>
-<td>Sets border at top and bottom of table, and below THEAD row if present. (custom attribute)</td>
-</tr>
-<tr>
-<td>*thead-underline*</td>
-<td>Sets border at bottom of THEAD row if present. (custom attribute added mPDF v1.1)</td>
-</tr>
-<tr>
-<td>line-height</td>
-<td>Sets default line-height for table cells as factor or % (value e.g. 1.3)</td>
-</tr>
-<tr>
-<td>line-stacking-strategy</td>
-<td>inline-line-height | block-line-height | max-height | grid-height
-
-As per draft CSS3 spec. (mPDF >= 6.0)
-
-Default = inline-line-height</td>
-</tr>
-<tr>
-<td>line-stacking-shift</td>
-<td>consider-shifts | disregard-shifts
-
-As per draft CSS3 spec. (mPDF >= 6.0)
-
-Default = consider-shifts</td>
-</tr>
-<tr>
-<td>*overflow*</td>
-<td>auto | hidden | visible | wrap
-
-Controls table layout if minimum width is too wide for page.</td>
-</tr>
-<tr>
-<td>direction</td>
-<td>rtl | ltr (mPDF >= 5.1)</td>
-</tr>
-<tr> <th>
-
-CAPTION
-
-</th>
-<td>caption-side</td>
-<td>top | bottom (mPDF >= 5.4) Right and left are not supported
-
+(mPDF >= 5.4)
 </td>
 </tr>
 <tr>
-<td rowspan="3">**THEAD, TFOOT**</td>
-<td>font-weight</td>
-<td>normal | bold</td>
+<td markdown="1">
+*rotate*
+</td>
+    <td>rotates the table 90 degress clockwise (90) or counter-clockwise (-90). Does not work with columns, and bookmarks will not be correctly placed (custom attribute)</td>
 </tr>
 <tr>
-<td>vertical-align</td>
-<td>top | middle | bottom</td>
+<td markdown="1">
+*autosize*
+</td>
+    <td>Shrinks a table to fit if width is too small to allow complete words to fit. The value (must be >=1) determines the maximum allowable factor to shrink i.e. autosize="2" will allow the font-size to be reduced to a minimum of 1/2 the original size. A value of 1 prevents automatic resizing of the table. (custom property)</td>
 </tr>
 <tr>
-<td>text-align</td>
-<td>left | center | right</td>
-</tr>
-<tr> <th rowspan="9">TR</th>
-<td>background-color</td>
-<td><span class="smallblock">COLOR</span></td>
+<td markdown="1">
+*topntail*
+</td>
+    <td>Sets border at top and bottom of table, and below THEAD row if present. (custom attribute)</td>
 </tr>
 <tr>
-<td>background, background-image, background-position, background-repeat, background-color</td>
-<td>
+<td markdown="1">
+*thead-underline*
+</td>
+    <td>Sets border at bottom of THEAD row if present. (custom attribute added mPDF v1.1)</td>
+</tr>
+<tr>
+    <td>line-height</td>
+    <td>Sets default line-height for table cells as factor or % (value e.g. 1.3)</td>
+</tr>
+<tr>
+    <td>line-stacking-strategy</td>
+<td markdown="1">
+inline-line-height \| block-line-height \| max-height \| grid-height
+
+As per draft CSS3 spec. (mPDF >= 6.0)
+
+Default = inline-line-height
+</td>
+</tr>
+<tr>
+    <td>line-stacking-shift</td>
+<td markdown="1">
+consider-shifts \| disregard-shifts
+
+As per draft CSS3 spec. (mPDF >= 6.0)
+
+Default = consider-shifts
+</td>
+</tr>
+<tr>
+<td markdown="1">
+*overflow*
+</td>
+<td markdown="1">
+auto \| hidden \| visible \| wrap
+
+Controls table layout if minimum width is too wide for page.
+</td>
+</tr>
+<tr>
+    <td>direction</td>
+    <td>rtl | ltr (mPDF >= 5.1)</td>
+</tr>
+<tr> 
+    <th>CAPTION</th>
+    <td>caption-side</td>
+    <td>top | bottom (mPDF >= 5.4) Right and left are not supported</td>
+</tr>
+<tr>
+    <th rowspan="3">THEAD, TFOOT</th>
+    <td>font-weight</td>
+    <td>normal | bold</td>
+</tr>
+<tr>
+    <td>vertical-align</td>
+    <td>top | middle | bottom</td>
+</tr>
+<tr>
+    <td>text-align</td>
+    <td>left | center | right</td>
+</tr>
+<tr> 
+    <th rowspan="9">TR</th>
+    <td>background-color</td>
+    <td><span class="smallblock">COLOR</span></td>
+</tr>
+<tr>
+    <td>background, background-image, background-position, background-repeat, background-color</td>
+<td markdown="1">
 
 background is parsed as per the CSS specification.
 
@@ -1083,7 +1057,7 @@ background-image in the form url(image.png) or url('image.png') or <span class="
 
 background-position is supported as per CSS2.1
 
-background-repeat: repeat | repeat-x | repeat-y | no-repeat
+background-repeat: repeat \| repeat-x \| repeat-y \| no-repeat
 
 background-attachment is parsed but has no effect.
 
@@ -1094,8 +1068,10 @@ See note below. (cf. <a href="{{ "/what-else-can-i-do/backgrounds-borders.html" 
 </td>
 </tr>
 <tr>
-<td>*background-image-opacity*</td>
-<td>
+<td markdown="1">
+*background-image-opacity*
+</td>
+<td markdown="1">
 
 Value between 0 and 1.0
 
@@ -1104,20 +1080,21 @@ Sets the opacity/transparency of the background image.
 </td>
 </tr>
 <tr>
-<td>border, border-right, border-left, border-top, border-bottom</td>
-<td>
+    <td>border, border-right, border-left, border-top, border-bottom</td>
+<td markdown="1">
 
 Size style and colour e.g.
 
-<span class="smallblock">LENGTH</span> double | solid | dashed | dotted | ridge | outset | groove | inset | hidden | none <span class="smallblock">COLOR</span> 
+<span class="smallblock">LENGTH</span> double \| solid \| dashed \| dotted \| ridge \| outset \| groove \| inset \| hidden \| none <span class="smallblock">COLOR</span> 
 
-NB Table &amp; cell borders accept: double | solid | dashed | dotted | ridge | outset | groove | inset | hidden | none (other block elements only support solid | dotted | dashed | double)
+NB Table & cell borders accept: double \| solid \| dashed \| dotted \| ridge \| outset \| groove \| inset \| hidden \| none (other block elements only support solid \| dotted \| dashed \| double)
 
-(mPDF >= 5.1)</td>
+(mPDF >= 5.1)
+</td>
 </tr>
 <tr>
-<td>border-color*, border-top-color, border-right-color, border-bottom-color, border-left-color</td>
-<td>
+    <td>border-color*, border-top-color, border-right-color, border-bottom-color, border-left-color</td>
+<td markdown="1">
 
 <span class="smallblock">COLOR</span>
 
@@ -1126,36 +1103,42 @@ NB Table &amp; cell borders accept: double | solid | dashed | dotted | ridge | o
 </td>
 </tr>
 <tr>
-<td>border-width*, border-top-width, border-right-width, border-bottom-width, border-left-width</td>
-<td>
+    <td>border-width*, border-top-width, border-right-width, border-bottom-width, border-left-width</td>
+<td markdown="1">
 
 <span class="smallblock">LENGTH</span> 
 
-(mPDF >= 5.1)</td>
+(mPDF >= 5.1)
+</td>
 </tr>
 <tr>
-<td>border-style*, border-top-style, border-right-style, border-bottom-style, border-left-style</td>
-<td>
+    <td>border-style*, border-top-style, border-right-style, border-bottom-style, border-left-style</td>
+<td markdown="1">
 
-double | solid | dashed | dotted | ridge | outset | groove | inset | hidden | none
+double \| solid \| dashed \| dotted \| ridge \| outset \| groove \| inset \| hidden \| none
 
 (mPDF >= 5.1)
 
 </td>
 </tr>
 <tr>
-<td>*text-rotate*</td>
-<td>Rotate the text inside table cells for this row. Accepted values are 1 - 90 for degrees anticlockwise, or -90 (only) for clockwise rotation. (custom attribute)</td>
+<td markdown="1">
+*text-rotate*
+</td>
+    <td>Rotate the text inside table cells for this row. Accepted values are 1 - 90 for degrees anticlockwise, or -90 (only) for clockwise rotation. (custom attribute)</td>
 </tr>
 <tr>
-<td>:nth-child()  <span class="smallblock">SELECTOR</span>* *</td>
-<td>odd | even | *a*n+*b*
+    <td>:nth-child()  <span class="smallblock">SELECTOR</span>* *</td>
+<td markdown="1">
+odd \| even \| *a*n+*b*
 
-As per CSS3 specification</td>
+As per CSS3 specification
+</td>
 </tr>
-<tr> <th rowspan="21">TD, TH</th>
-<td>background, background-image, background-position, background-repeat, background-color</td>
-<td>
+<tr> 
+    <th rowspan="21">TD, TH</th>
+    <td>background, background-image, background-position, background-repeat, background-color</td>
+<td markdown="1">
 
 background is parsed as per the CSS specification.
 
@@ -1163,7 +1146,7 @@ background-image in the form url(image.png) or url('image.png') or <span class="
 
 background-position is supported as per CSS2.1
 
-background-repeat: repeat | repeat-x | repeat-y | no-repeat
+background-repeat: repeat \| repeat-x \| repeat-y \| no-repeat
 
 background-attachment is parsed but has no effect.
 
@@ -1174,8 +1157,10 @@ See note below.
 </td>
 </tr>
 <tr>
-<td>*background-gradient*</td>
-<td>
+<td markdown="1">
+*background-gradient*
+</td>
+<td markdown="1">
 
 Defines a linear or radial colour gradient for the background.
 
@@ -1192,8 +1177,10 @@ x, y and radius are values between 0 and 1
 </td>
 </tr>
 <tr>
-<td>*background-image-opacity*</td>
-<td>
+<td markdown="1">
+*background-image-opacity*
+</td>
+<td markdown="1">
 
 Value between 0 and 1.0
 
@@ -1202,8 +1189,11 @@ Sets the opacity/transparency of the background image.
 </td>
 </tr>
 <tr>
-<td>*background-image-resize*</td>
-<td>0 - No resizing (default)
+<td markdown="1">
+*background-image-resize*
+</td>
+<td markdown="1">
+0 - No resizing (default)
 
 1 - Shrink-to-fit w (keep aspect ratio)
 
@@ -1215,27 +1205,24 @@ Sets the opacity/transparency of the background image.
 
 5 - Resize-to-fit h (keep aspect ratio)
 
-6 - Resize-to-fit w and h</td>
+6 - Resize-to-fit w and h
+</td>
 </tr>
 <tr>
-<td>
-
-border, border-right, border-left, border-top, border-bottom
-
-</td>
-<td>
+    <td>border, border-right, border-left, border-top, border-bottom</td>
+<td markdown="1">
 
 Size style and colour e.g.
 
-<span class="smallblock">LENGTH</span> double | solid | dashed | dotted | ridge | outset | groove | inset | hidden | none <span class="smallblock">COLOR</span> 
+<span class="smallblock">LENGTH</span> double \| solid \| dashed \| dotted \| ridge \| outset \| groove \| inset \| hidden \| none <span class="smallblock">COLOR</span> 
 
-NB Table &amp; cell borders accept: double | solid | dashed | dotted | ridge | outset | groove | inset | hidden | none (other block elements only support solid | dotted | dashed | double)
+NB Table & cell borders accept: double \| solid \| dashed \| dotted \| ridge \| outset \| groove \| inset \| hidden \| none (other block elements only support solid \| dotted \| dashed \| double)
 
 </td>
 </tr>
 <tr>
-<td>border-color*, border-top-color, border-right-color, border-bottom-color, border-left-color</td>
-<td>
+    <td>border-color*, border-top-color, border-right-color, border-bottom-color, border-left-color</td>
+<td markdown="1">
 
 <span class="smallblock">COLOR</span>
 
@@ -1244,58 +1231,53 @@ NB Table &amp; cell borders accept: double | solid | dashed | dotted | ridge | o
 </td>
 </tr>
 <tr>
-<td>border-width*, border-top-width, border-right-width, border-bottom-width, border-left-width</td>
-<td>
+    <td>border-width*, border-top-width, border-right-width, border-bottom-width, border-left-width</td>
+<td markdown="1">
 
 <span class="smallblock">LENGTH</span> 
 
-(mPDF >= 4.0)</td>
+(mPDF >= 4.0)
+</td>
 </tr>
 <tr>
-<td>border-style*, border-top-style, border-right-style, border-bottom-style, border-left-style</td>
-<td>
+    <td>border-style*, border-top-style, border-right-style, border-bottom-style, border-left-style</td>
+<td markdown="1">
 
-double | solid | dashed | dotted | ridge | outset | groove | inset | hidden | none
+double \| solid \| dashed \| dotted \| ridge \| outset \| groove \| inset \| hidden \| none
 
 (mPDF >= 4.0)
 
 </td>
 </tr>
 <tr>
-<td>padding*, padding-right, padding-left, padding-top, padding-bottom</td>
-<td>
+    <td>padding*, padding-right, padding-left, padding-top, padding-bottom</td>
+    <td><span class="smallblock">LENGTH</span></td>
+</tr>
+<tr>
+    <td>width</td>
+    <td><span class="smallblock">LENGTH</span></td>
+</tr>
+<tr>
+    <td>height</td>
+    <td><span class="smallblock">LENGTH</span> (but not %) (mPDF >= 4.0)</td>
+</tr>
+<tr>
+    <td><span class="smallblock">COMMON TEXT STYLES</span></td>
+    <td><span class="smallblock">See <a href="#common-text-styles">below</a></span></td>
+</tr>
+<tr>
+    <td>white-space</td>
+    <td>nowrap</td>
+</tr>
+<tr>
+    <td>vertical-align</td>
+    <td>top | middle | bottom</td>
+</tr>
+<tr>
+    <td>text-align</td>
+<td markdown="1">
 
-<span class="smallblock">LENGTH</span>
-
-</td>
-</tr>
-<tr>
-<td>width</td>
-<td><span class="smallblock">LENGTH</span></td>
-</tr>
-<tr>
-<td>height</td>
-<td><span class="smallblock">LENGTH</span> (but not %) (mPDF >= 4.0)
-
-</td>
-</tr>
-<tr>
-<td><span class="smallblock">COMMON TEXT STYLES</span></td>
-<td><span class="smallblock">See below</span></td>
-</tr>
-<tr>
-<td>white-space</td>
-<td>nowrap</td>
-</tr>
-<tr>
-<td>vertical-align</td>
-<td>top|middle|bottom</td>
-</tr>
-<tr>
-<td>text-align</td>
-<td>
-
-left | right | center
+left \| right \| center
 
 From mPDF 5.7, also supports a decimal-mark alignment followed by a default e.g.
 
@@ -1308,125 +1290,131 @@ text-align: '\66B' center;
 </td>
 </tr>
 <tr>
-<td>*text-rotate*</td>
-<td>Rotates the text in a table cell. Accepted values are 1-90 for degrees anticlockwise, or -90 (only) for clockwise rotation. (custom attribute)</td>
+<td markdown="1">
+*text-rotate*
+</td>
+    <td>Rotates the text in a table cell. Accepted values are 1-90 for degrees anticlockwise, or -90 (only) for clockwise rotation. (custom attribute)</td>
 </tr>
 <tr>
-<td>line-stacking-strategy</td>
-<td>inline-line-height | block-line-height | max-height | grid-height
+    <td>line-stacking-strategy</td>
+<td markdown="1">
+inline-line-height \| block-line-height \| max-height \| grid-height
 
 As per draft CSS3 spec. (mPDF >= 6.0)
 
-Default = inline-line-height</td>
-</tr>
-<tr>
-<td>line-stacking-shift</td>
-<td>consider-shifts | disregard-shifts
-
-As per draft CSS3 spec. (mPDF >= 6.0)
-
-Default = consider-shifts</td>
-</tr>
-<tr>
-<td>hyphens* *</td>
-<td>
-
-none | manual | auto (default = manual)
-
-As per CSS. (mPDF  >= 5.7)</td>
-</tr>
-<tr>
-<td>:nth-child()  <span class="smallblock">SELECTOR</span></td>
-<td>odd | even | *a*n+*b*
-
-As per CSS3 specification</td>
-</tr>
-<tr>
-<td>direction</td>
-<td>rtl | ltr (mPDF >= 6.0)</td>
-</tr>
-</tbody> </table>
-<table class="table"> <thead>
-<tr> <th>HTML Tag</th>
-<td>Property</td>
-<td>Values allowed &amp; Notes
-
+Default = inline-line-height
 </td>
 </tr>
+<tr>
+    <td>line-stacking-shift</td>
+<td markdown="1">
+consider-shifts \| disregard-shifts
+
+As per draft CSS3 spec. (mPDF >= 6.0)
+
+Default = consider-shifts
+</td>
+</tr>
+<tr>
+    <td>hyphens* *</td>
+<td markdown="1">
+none \| manual \| auto (default = manual)
+
+As per CSS. (mPDF  >= 5.7)
+</td>
+</tr>
+<tr>
+    <td>:nth-child()  <span class="smallblock">SELECTOR</span></td>
+<td markdown="1">
+odd \| even \| *a*n+*b*
+
+As per CSS3 specification
+</td>
+</tr>
+<tr>
+    <td>direction</td>
+    <td>rtl | ltr (mPDF >= 6.0)</td>
+</tr>
+</tbody> </table>
+
+<table class="table"> <thead>
+<tr> 
+    <th>HTML Tag</th>
+    <td>Property</td>
+    <td>Values allowed &amp; Notes</td>
+</tr>
 </thead> <tbody>
-<tr> <th rowspan="7">HR</th>
-<td>width</td>
-<td><span class="smallblock">LENGTH</span></td>
+<tr>
+    <th rowspan="7">HR</th>
+    <td>width</td>
+    <td><span class="smallblock">LENGTH</span></td>
 </tr>
 <tr>
-<td>text-align</td>
-<td>left|right|center</td>
+    <td>text-align</td>
+    <td>left | right | center</td>
 </tr>
 <tr>
-<td>color</td>
-<td><span class="smallblock">COLOR</span></td>
+    <td>color</td>
+    <td><span class="smallblock">COLOR</span></td>
 </tr>
 <tr>
-<td>height</td>
-<td>i.e. line-width. <span class="smallblock">LENGTH</span></td>
+    <td>height</td>
+    <td>i.e. line-width. <span class="smallblock">LENGTH</span></td>
 </tr>
 <tr>
-<td>margin-top, margin-bottom</td>
-<td><span class="smallblock">LENGTH</span></td>
+    <td>margin-top, margin-bottom</td>
+    <td><span class="smallblock">LENGTH</span></td>
 </tr>
 <tr>
-<td>margin-left, margin-right</td>
-<td>auto|0 (only) are supported as an alternative way to align a HR of less than 100% width. Values for margin-left: 0; margin-right: auto; will align the HR to the left etc.</td>
+    <td>margin-left, margin-right</td>
+    <td>auto | 0 (only) are supported as an alternative way to align a HR of less than 100% width. Values for margin-left: 0; margin-right: auto; will align the HR to the left etc.</td>
 </tr>
 <tr>
-<td>clear</td>
-<td>left|right|both</td>
+    <td>clear</td>
+    <td>left | right | both</td>
 </tr>
-<tr> <th rowspan="18">
+<tr> 
+    <th rowspan="18">IMG</th>
+    <td>vertical-align</td>
+<td markdown="1">
 
-IMG
-
-</th>
-<td>vertical-align</td>
-<td>
-
-top|middle|bottom|baseline|text-bottom|text-top
+top \| middle \| bottom \| baseline \| text-bottom \| text-top
 
 (Full support only from mPDF 4.2)
 
 </td>
 </tr>
 <tr>
-<td>margin, margin-right, margin-left, margin-top, margin-bottom</td>
-<td><span class="smallblock">LENGTH</span></td>
+    <td>margin, margin-right, margin-left, margin-top, margin-bottom</td>
+    <td><span class="smallblock">LENGTH</span></td>
 </tr>
 <tr>
-<td>border, border-right, border-left, border-top, border-bottom</td>
-<td>
+    <td>border, border-right, border-left, border-top, border-bottom</td>
+<td markdown="1">
 
 Must be full declaration of size style and colour e.g.
 
-0.1pt solid|dotted|dashed #cccccc
+0.1pt solid \| dotted \| dashed #cccccc
 
 Will also accept #cccccc 0.1pt solid (which is generated by IE WYSIWYG editor)
 
 and (from mPDF 1.4) solid 3mm #000000
 
-medium | thin | thick accepted for size
+medium \| thin \| thick accepted for size
 
 </td>
 </tr>
 <tr>
-<td>padding*, padding-right, padding-left, padding-top, padding-bottom</td>
-<td><span class="smallblock">LENGTH</span></td>
+    <td>padding*, padding-right, padding-left, padding-top, padding-bottom</td>
+    <td><span class="smallblock">LENGTH</span></td>
 </tr>
 <tr>
-<td>background-color</td>
-<td><span class="smallblock">COLOR</span>  (mPDF >= 5.7.3)<span class="smallblock"> </span></td>
+    <td>background-color</td>
+    <td><span class="smallblock">COLOR</span>  (mPDF >= 5.7.3)<span class="smallblock"> </span></td>
 </tr>
 <tr>
-<td>opacity</td>
-<td>
+    <td>opacity</td>
+<td markdown="1">
 
 Value between 0 and 1.0
 
@@ -1437,22 +1425,20 @@ Sets the opacity/transparency of the image.
 </td>
 </tr>
 <tr>
-<td>image-orientation</td>
-<td><span class="smallblock">ANGLE</span> as deg, rad, or grad (as per draft CSS3)  mPDF >= 5.1</td>
+    <td>image-orientation</td>
+    <td><span class="smallblock">ANGLE</span> as deg, rad, or grad (as per draft CSS3)  mPDF >= 5.1</td>
 </tr>
 <tr>
-<td>image-resolution</td>
-<td>normal | [ from-image
-
- &lt;dpi&gt; ](as per draft CSS3)  mPDF >= 5.1</td>
-</tr>
-<tr>
-<td>image-rendering
-
+    <td>image-resolution</td>
+<td markdown="1">
+normal \| [ from-image \<dpi\> ] (as per draft CSS3)  mPDF >= 5.1
 </td>
-<td>
+</tr>
+<tr>
+    <td>image-rendering</td>
+<td markdown="1">
 
-auto | crisp-edges | optimizequality | smooth  (as per draft CSS3)
+auto \| crisp-edges \| optimizequality \| smooth  (as per draft CSS3)
 
 (mPDF >= 6.0)
 
@@ -1469,20 +1455,24 @@ smooth - interpolation enabled
 </td>
 </tr>
 <tr>
-<td>*gradient-mask*</td>
-<td><span class="smallblock">GRADIENT</span>  (see notes below)  mPDF >= 5.1</td>
+<td markdown="1">
+*gradient-mask*
+</td>
+    <td><span class="smallblock">GRADIENT</span>  (see notes below)  mPDF >= 5.1</td>
 </tr>
 <tr>
-<td>display</td>
-<td>none</td>
+    <td>display</td>
+    <td>none</td>
 </tr>
 <tr>
-<td>visibility</td>
-<td>visible | hidden | *printonly* | *screenonly*  (mPDF >= 5.4)</td>
+    <td>visibility</td>
+<td markdown="1">
+visible \| hidden \| *printonly* \| *screenonly*  (mPDF >= 5.4)
+</td>
 </tr>
 <tr>
-<td>transform</td>
-<td>
+    <td>transform</td>
+<td markdown="1">
 
 All CSS3 transform functions are supported except matrix() i.e.
 
@@ -1499,168 +1489,156 @@ cf. <a href="http://www.w3.org/TR/css3-transforms/#typedef-transform-function">h
 </td>
 </tr>
 <tr>
-<td>float</td>
-<td>left | right (cf. <a href="{{ "/what-else-can-i-do/images.html" | prepend: site.baseurl }}">Images</a>)
+    <td>float</td>
+    <td>left | right (cf. <a href="{{ "/what-else-can-i-do/images.html" | prepend: site.baseurl }}">Images</a>)</td>
+</tr>
+<tr>
+    <td>z-index</td>
+    <td>Sets a layer in the PDF document. See <a href="{{ "/what-else-can-i-do/layers.html" | prepend: site.baseurl }}">Layers</a>.</td>
+</tr>
+<tr>
+    <td>(vspace, hspace)</td>
+    <td>Attributes - set values for margin-left/right or margin-top/bottom</td>
+</tr>
+<tr>
+    <td>width, height</td>
+    <td><span class="smallblock">LENGTH</span>. NB the inline attributes width="" and height="" are also supported</td>
+</tr>
+<tr>
+    <td>min-width, min-height, max-width, max-height</td>
+    <td><span class="smallblock">LENGTH</span>. (mPDF >= 5.6)</td>
+</tr>
+<tr> 
+    <th rowspan="3">SELECT</th>
+    <td>font-family</td>
+    <td><span class="smallblock">FONT-FAMILY</span></td>
+</tr>
+<tr>
+    <td>font-size</td>
+    <td><span class="smallblock">FONT-SIZE</span></td>
+</tr>
+<tr>
+    <td>color</td>
+    <td><span class="smallblock">COLOR</span></td>
+</tr>
+<tr>
+    <th rowspan="7">TEXTAREA</th>
+    <td>width, height</td>
+    <td><span class="smallblock">LENGTH</span>. NB the inline attributes cols="" and rows="" are also supported</td>
+</tr>
+<tr>
+    <td>font-family</td>
+    <td><span class="smallblock">FONT-FAMILY</span></td>
+</tr>
+<tr>
+    <td>font-size</td>
+    <td><span class="smallblock">FONT-SIZE</span></td>
+</tr>
+<tr>
+    <td>color</td>
+    <td><span class="smallblock">COLOR</span></td>
+</tr>
+<tr>
+    <td>vertical-align</td>
+<td markdown="1">
 
-</td>
-</tr>
-<tr>
-<td>z-index</td>
-<td>Sets a layer in the PDF document. See <a href="{{ "/what-else-can-i-do/layers.html" | prepend: site.baseurl }}">Layers</a>.</td>
-</tr>
-<tr>
-<td>(vspace, hspace)</td>
-<td>Attributes - set values for margin-left/right or margin-top/bottom
-
-</td>
-</tr>
-<tr>
-<td>width, height</td>
-<td><span class="smallblock">LENGTH</span>. NB the inline attributes width="" and height="" are also supported</td>
-</tr>
-<tr>
-<td>min-width, min-height, max-width, max-height
-
-</td>
-<td><span class="smallblock">LENGTH</span>. (mPDF >= 5.6)
-
-</td>
-</tr>
-<tr> <th rowspan="3">
-
-SELECT
-
-</th>
-<td>font-family</td>
-<td><span class="smallblock">FONT-FAMILY</span></td>
-</tr>
-<tr>
-<td>font-size</td>
-<td><span class="smallblock">FONT-SIZE</span></td>
-</tr>
-<tr>
-<td>color</td>
-<td><span class="smallblock">COLOR</span></td>
-</tr>
-<tr> <th rowspan="7">TEXTAREA</th>
-<td>width, height</td>
-<td><span class="smallblock">LENGTH</span>. NB the inline attributes cols="" and rows="" are also supported</td>
-</tr>
-<tr>
-<td>font-family</td>
-<td><span class="smallblock">FONT-FAMILY</span></td>
-</tr>
-<tr>
-<td>font-size</td>
-<td><span class="smallblock">FONT-SIZE</span></td>
-</tr>
-<tr>
-<td>color</td>
-<td><span class="smallblock">COLOR</span></td>
-</tr>
-<tr>
-<td>vertical-align</td>
-<td>
-
-top|middle|bottom|baseline|text-bottom|text-top
+top \| middle \| bottom \| baseline \| text-bottom \| text-top
 
 (Full support only from mPDF 4.2)
 
 </td>
 </tr>
 <tr>
-<td>border-color</td>
-<td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
+    <td>border-color</td>
+    <td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
 </tr>
 <tr>
-<td>background-color</td>
-<td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
+    <td>background-color</td>
+    <td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
 </tr>
-<tr> <th>INPUT (type=IMAGE)</th>
-<td>width, height</td>
-<td><span class="smallblock">LENGTH</span></td>
+<tr> 
+    <th>INPUT (type=IMAGE)</th>
+    <td>width, height</td>
+    <td><span class="smallblock">LENGTH</span></td>
 </tr>
-<tr> <th rowspan="5">INPUT (type=BUTTON|SUBMIT|RESET)</th>
-<td>font-family</td>
-<td><span class="smallblock">FONT-FAMILY</span>  Active Forms only (mPDF >= 5.3)</td>
-</tr>
-<tr>
-<td>font-size</td>
-<td><span class="smallblock">FONT-SIZE</span>  Active Forms only (mPDF >= 5.3)</td>
+<tr> 
+    <th rowspan="5">INPUT (type=BUTTON| SUBMIT|RESET)</th>
+    <td>font-family</td>
+    <td><span class="smallblock">FONT-FAMILY</span>  Active Forms only (mPDF >= 5.3)</td>
 </tr>
 <tr>
-<td>color</td>
-<td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
+    <td>font-size</td>
+    <td><span class="smallblock">FONT-SIZE</span>  Active Forms only (mPDF >= 5.3)</td>
 </tr>
 <tr>
-<td>border-color</td>
-<td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
+    <td>color</td>
+    <td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
 </tr>
 <tr>
-<td>background-color</td>
-<td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
+    <td>border-color</td>
+    <td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
 </tr>
-<tr> <th rowspan="2">INPUT (type=CHECKBOX|RADIO)
-
-</th>
-<td>font-size</td>
-<td><span class="smallblock">FONT-SIZE</span> (sets size of glyph). Not inherited.
-
+<tr>
+    <td>background-color</td>
+    <td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
+</tr>
+<tr> 
+    <th rowspan="2">INPUT (type=CHECKBOX| RADIO)</th>
+    <td>font-size</td>
+    <td><span class="smallblock">FONT-SIZE</span> (sets size of glyph). Not inherited.</td>
+</tr>
+<tr>
+    <td>color</td>
+    <td><span class="smallblock">COLOR</span>. Not inherited.</td>
+</tr>
+<tr> 
+    <th rowspan="6">INPUT (type=PASSWORD| TEXT)</th>
+    <td>width</td>
+    <td><span class="smallblock">LENGTH</span>. NB the inline attribute size="" is also supported</td>
+</tr>
+<tr>
+    <td>font-family</td>
+    <td><span class="smallblock">FONT-FAMILY</span></td>
+</tr>
+<tr>
+    <td>font-size</td>
+    <td><span class="smallblock">FONT-SIZE</span></td>
+</tr>
+<tr>
+    <td>color</td>
+    <td><span class="smallblock">COLOR</span></td>
+</tr>
+<tr>
+    <td>border-color</td>
+    <td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
+</tr>
+<tr>
+    <td>background-color</td>
+    <td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
+</tr>
+<tr> 
+    <th>BR</th>
+    <td>clear</td>
+    <td>left | right | both</td>
+</tr>
+<tr> 
+    <th>DOTTAB</th>
+<td markdown="1">
+*outdent*
 </td>
+    <td><span class="smallblock">LENGTH</span>. (mPDF >= 5.7)</td>
 </tr>
-<tr>
-<td>color</td>
-<td><span class="smallblock">COLOR</span>. Not inherited.</td>
-</tr>
-<tr> <th rowspan="6">INPUT (type=PASSWORD|TEXT)</th>
-<td>width</td>
-<td><span class="smallblock">LENGTH</span>. NB the inline attribute size="" is also supported</td>
-</tr>
-<tr>
-<td>font-family</td>
-<td><span class="smallblock">FONT-FAMILY</span></td>
-</tr>
-<tr>
-<td>font-size</td>
-<td><span class="smallblock">FONT-SIZE</span></td>
-</tr>
-<tr>
-<td>color</td>
-<td><span class="smallblock">COLOR</span></td>
-</tr>
-<tr>
-<td>border-color</td>
-<td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
-</tr>
-<tr>
-<td>background-color</td>
-<td><span class="smallblock">COLOR</span>  Active Forms only (mPDF >= 5.3)</td>
-</tr>
-<tr> <th>BR
-
-</th>
-<td>clear
-
-</td>
-<td>left|right|both
-
-</td>
-</tr>
-<tr> <th>DOTTAB</th>
-<td>*outdent*</td>
-<td><span class="smallblock">LENGTH</span>. (mPDF >= 5.7)</td>
-</tr>
-<tr> <th rowspan="4">
-
+<tr> 
+<th rowspan="4" markdown="1">
 @page
 
-@page &lt;named&gt; 
+@page \<named\> 
 
 </th>
-<td>size</td>
-<td>
+    <td>size</td>
+<td markdown="1">
 
-&lt;length&gt;{1,2} | auto | portrait | landscape
+\<length\>{1,2} \| auto \| portrait \| landscape
 
 Note: 'em' 'ex' and % are not allowed
 
@@ -1671,10 +1649,10 @@ Sets the size of the 'page-box', which is usually used with a constant size shee
 </td>
 </tr>
 <tr>
-<td>sheet-size</td>
-<td>
+    <td>sheet-size</td>
+<td markdown="1">
 
-&lt;length&gt;{2} | A4 | A4-L etc.
+\<length\>{2} \| A4 \| A4-L etc.
 
 Note: 'em' 'ex' and % are not allowed
 
@@ -1683,36 +1661,35 @@ Length values are width and height e.g. size: 8.5in 11in; Any of the standard sh
 </td>
 </tr>
 <tr>
-<td>odd-header-name, even-header-name, odd-footer-name, even-footer-name</td>
-<td>
+    <td>odd-header-name, even-header-name, odd-footer-name, even-footer-name</td>
+<td markdown="1">
 
 A named Header or Footer. HTML headers/footers must precede the name with <span class="parameter">$html_</span>
 
 NB This was the original form, and still takes preference over header and footer which can be set using the pseudo-selectors e.g. :right
 
 The name *_default* can be used to allow the current non-HTML header to remain unchanged (mPDF >= 5.1)
-
 </td>
 </tr>
 <tr>
-<td>margin, margin-left, margin-right, margin-top, margin-bottom</td>
-<td><span class="smallblock">LENGTH</span> (% refers to page-box width for left/right, of height for top/bottom)</td>
+    <td>margin, margin-left, margin-right, margin-top, margin-bottom</td>
+    <td><span class="smallblock">LENGTH</span> (% refers to page-box width for left/right, of height for top/bottom)</td>
 </tr>
-<tr> <th rowspan="11">
-
+<tr> 
+<th rowspan="11" markdown="1">
 @page  
 
-@page :right
+@page :right
 
-@page :left
+@page :left
 
-@page :first
+@page :first
 
-@page &lt;named&gt;
+@page \<named\>
 
 </th>
-<td>margin-top, margin-bottom</td>
-<td>
+    <td>margin-top, margin-bottom</td>
+<td markdown="1">
 
 <span class="smallblock">LENGTH</span> (% refers to page-box width for left/right, of height for top/bottom)
 
@@ -1723,30 +1700,28 @@ Note that left and right margins cannot be changed when using a page selector.
 </td>
 </tr>
 <tr>
-<td>*margin-header,
-
-margin-footer*</td>
-<td><span class="smallblock">LENGTH</span></td>
+<td markdown="1">
+*margin-header, margin-footer*
+</td>
+    <td><span class="smallblock">LENGTH</span></td>
 </tr>
 <tr>
-<td>marks
+    <td>marks</td>
+<td markdown="1">
 
-</td>
-<td>
-
-crop | cross | none
+crop \| cross \| none
 
 From mPDF 5.1 crop and cross can be used together.
 
 </td>
 </tr>
 <tr>
-<td>header, footer</td>
-<td>A named Header or Footer. HTML headers/footers must precede the name with <span class="parameter">$html_</span> (from mPDF 4.2)</td>
+    <td>header, footer</td>
+    <td>A named Header or Footer. HTML headers/footers must precede the name with <span class="parameter">$html_</span> (from mPDF 4.2)</td>
 </tr>
 <tr>
-<td>background, background-image, background-position, background-repeat, background-color</td>
-<td>
+    <td>background, background-image, background-position, background-repeat, background-color</td>
+<td markdown="1">
 
 background is parsed as per the CSS specification.
 
@@ -1754,7 +1729,7 @@ background-image in the form url(image.png) or url('image.png') supported.
 
 background-position is supported as per CSS2.1
 
-background-repeat: repeat | repeat-x | repeat-y | no-repeat
+background-repeat: repeat \| repeat-x \| repeat-y \| no-repeat
 
 background-attachment is parsed but has no effect.
 
@@ -1763,8 +1738,10 @@ See note below. (cf. <a href="{{ "/what-else-can-i-do/backgrounds-borders.html" 
 </td>
 </tr>
 <tr>
-<td>*background-image-opacity*</td>
-<td>
+<td markdown="1">
+*background-image-opacity*
+</td>
+<td markdown="1">
 
 Value between 0 and 1.0
 
@@ -1773,8 +1750,11 @@ Sets the opacity/transparency of the background image.
 </td>
 </tr>
 <tr>
-<td>*background-image-resize*</td>
-<td>0 - No resizing (default)
+<td markdown="1">
+*background-image-resize*
+</td>
+<td markdown="1">
+0 - No resizing (default)
 
 1 - Shrink-to-fit w (keep aspect ratio)
 
@@ -1791,8 +1771,10 @@ Sets the opacity/transparency of the background image.
 </td>
 </tr>
 <tr>
-<td>*background-gradient*</td>
-<td>
+<td markdown="1">
+*background-gradient*
+</td>
+<td markdown="1">
 
 Defines a linear or radial colour gradient for the background.
 
@@ -1807,212 +1789,224 @@ x, y and radius are values between 0 and 1
 </td>
 </tr>
 <tr>
-<td>*resetpagenum*</td>
-<td><span class="smallblock">INTEGER</span> Reset page numbering. Use with **:first**</td>
+<td markdown="1">
+*resetpagenum*
+</td>
+<td markdown="1">
+<span class="smallblock">INTEGER</span> Reset page numbering. Use with **:first**
+</td>
 </tr>
 <tr>
-<td>*pagenumstyle*</td>
-<td>1 | A | a | I | i  <span class="smallblock"> </span>See &lt;<a href="{{ "/reference/html-control-tags/pagebreak.html" | prepend: site.baseurl }}">pagebreak</a>&gt; for details</td>
+<td markdown="1">
+*pagenumstyle*
+</td>
+    <td>1 | A | a | I | i  <span class="smallblock"> </span>See &lt;<a href="{{ "/reference/html-control-tags/pagebreak.html" | prepend: site.baseurl }}">pagebreak</a>&gt; for details</td>
 </tr>
 <tr>
-<td>*suppress*</td>
-<td>on | off | 1 | 0  See &lt;<a href="{{ "/reference/html-control-tags/pagebreak.html" | prepend: site.baseurl }}">pagebreak</a>&gt; for details</td>
-</tr>
-</tbody> </table>
+<td markdown="1">
+*suppress*
+</td>
+<td markdown="1">
+on \| off \| 1 \| 0  
 
-**Common Text Styles**
+See &lt;<a href="{{ "/reference/html-control-tags/pagebreak.html" | prepend: site.baseurl }}">pagebreak</a>&gt; for details
+</td>
+</tr>
+</tbody></table>
+
+
+## Common Text Styles
+
 
 <table class="table"> <tbody>
 <tr>
-<td rowspan="25">COMMON TEXT STYLES</td>
-<td>font-family</td>
-<td><span class="smallblock">FONT-FAMILY</span></td>
+    <td rowspan="25">COMMON TEXT STYLES</td>
+    <td>font-family</td>
+    <td><span class="smallblock">FONT-FAMILY</span></td>
 </tr>
 <tr>
-<td>font-size</td>
-<td>
-
-<span class="smallblock">FONT-SIZE</span>
-
-</td>
+    <td>font-size</td>
+    <td>
+        <span class="smallblock">FONT-SIZE</span>
+    </td>
 </tr>
 <tr>
-<td>font-style</td>
-<td>italic | oblique | normal</td>
+    <td>font-style</td>
+    <td>italic | oblique | normal</td>
 </tr>
 <tr>
-<td>font-weight</td>
-<td>bold | normal (only)</td>
+    <td>font-weight</td>
+    <td>bold | normal (only)</td>
 </tr>
 <tr>
-<td>font</td>
-<td>Shorthand form, as per CSS2 specification (mPDF >= 4.0)</td>
+    <td>font</td>
+    <td>Shorthand form, as per CSS2 specification (mPDF >= 4.0)</td>
 </tr>
 <tr>
-<td>font-variant</td>
-<td>
+    <td>font-variant</td>
+<td markdown="1">
 
-normal | none | [ &lt;common-lig-values&gt;
+normal \| none \| [ \<common-lig-values\>
 
- &lt;discretionary-lig-values&gt;
+\<discretionary-lig-values\>
 
- &lt;historical-lig-values&gt;
+\<historical-lig-values\>
 
- &lt;contextual-alt-values&gt;
+\<contextual-alt-values\>
 
- historical-forms
+historical-forms
 
- [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ]
+[ small-caps \| all-small-caps \| petite-caps \| all-petite-caps \| unicase \| titling-caps ]
 
- &lt;numeric-figure-values&gt;
+\<numeric-figure-values\>
 
- &lt;numeric-spacing-values&gt;
+\<numeric-spacing-values\>
 
- &lt;numeric-fraction-values&gt;
+\<numeric-fraction-values\>
 
- ordinal
+ordinal
 
- slashed-zero ]
+slashed-zero ]
 
 (mPDF >= 6.0)
 
 </td>
 </tr>
 <tr>
-<td>font-variant-position
+    <td>font-variant-position</td>
+<td markdown="1">
 
-</td>
-<td>
-
-normal | sub | super
+normal \| sub \| super
 
 (mPDF >= 6.0)
 
 </td>
 </tr>
 <tr>
-<td>font-variant-caps</td>
-<td>
+    <td>font-variant-caps</td>
+<td markdown="1">
 
-normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps
-
-(mPDF >= 6.0)
-
-</td>
-</tr>
-<tr>
-<td>font-variant-ligatures</td>
-<td>
-
-normal | none | [ &lt;common-lig-values&gt;
-
- &lt;discretionary-lig-values&gt;
-
- &lt;historical-lig-values&gt;
-
- &lt;contextual-alt-values&gt; ]
-
-(mPDF >= 6.0)
-
-&lt;common-lig-values&gt;       = [ common-ligatures | no-common-ligatures ]
-
-&lt;discretionary-lig-values&gt; = [ discretionary-ligatures | no-discretionary-ligatures ]
-
-&lt;historical-lig-values&gt;      = [ historical-ligatures | no-historical-ligatures ]
-
-&lt;contextual-alt-values&gt;    = [ contextual | no-contextual ]
-
-</td>
-</tr>
-<tr>
-<td>font-variant-numeric</td>
-<td>
-
-normal | [ &lt;numeric-figure-values&gt;
-
- &lt;numeric-spacing-values&gt;
-
- &lt;numeric-fraction-values&gt;
-
- ordinal
-
- slashed-zero ]
+normal \| small-caps \| all-small-caps \| petite-caps \| all-petite-caps \| unicase \| titling-caps
 
 (mPDF >= 6.0)
 
 </td>
 </tr>
 <tr>
-<td>font-variant-alternates</td>
-<td>
+    <td>font-variant-ligatures</td>
+<td markdown="1">
 
-Only [normal | historical-forms] supported (i.e. most are NOT supported)
+normal \| none \| [ \<common-lig-values\>
+
+\<discretionary-lig-values\>
+
+\<historical-lig-values\>
+
+\<contextual-alt-values\> ]
+
+(mPDF >= 6.0)
+
+\<common-lig-values\>       = [ common-ligatures \| no-common-ligatures ]
+
+\<discretionary-lig-values\> = [ discretionary-ligatures \| no-discretionary-ligatures ]
+
+\<historical-lig-values\>      = [ historical-ligatures \| no-historical-ligatures ]
+
+\<contextual-alt-values\>    = [ contextual \| no-contextual ]
+
+</td>
+</tr>
+<tr>
+    <td>font-variant-numeric</td>
+<td markdown="1">
+
+normal \| [ \<numeric-figure-values\>
+
+\<numeric-spacing-values\>
+
+\<numeric-fraction-values\>
+
+ordinal
+
+slashed-zero ]
 
 (mPDF >= 6.0)
 
 </td>
 </tr>
 <tr>
-<td>font-language-override</td>
-<td>3-letter case-sensitive OpenType language system tag
+    <td>font-variant-alternates</td>
+<td markdown="1">
+
+Only [normal \| historical-forms] supported (i.e. most are NOT supported)
 
 (mPDF >= 6.0)
 
 </td>
 </tr>
 <tr>
-<td>font-feature-settings</td>
-<td>
-
-Comma separated list of &lt;feature-tag-value&gt; with the following syntax:
-
-&lt;feature-tag-value&gt; = &lt;string&gt; [ &lt;integer&gt; | on | off ]?
+    <td>font-language-override</td>
+<td markdown="1">
+3-letter case-sensitive OpenType language system tag
 
 (mPDF >= 6.0)
 
 </td>
 </tr>
 <tr>
-<td>font-kerning</td>
-<td>
+    <td>font-feature-settings</td>
+<td markdown="1">
 
-auto | normal | none (mPDF >= 5.1)
+Comma separated list of \<feature-tag-value\> with the following syntax:
+
+\<feature-tag-value\> = \<string\> [ \<integer\> \| on \| off ]?
+
+(mPDF >= 6.0)
+
+</td>
+</tr>
+<tr>
+    <td>font-kerning</td>
+<td markdown="1">
+
+auto \| normal \| none (mPDF >= 5.1)
 
 auto and normal both have the effect of turning kerning on, as long as
 
-`$mpdf-&gt;useKerning = true;`
+`$mpdf->useKerning = true;`
 
 </td>
 </tr>
 <tr>
-<td>vertical-align</td>
-<td>super | sub | baseline | <span class="smallblock">LENGTH</span>  (mPDF >= 5.7.3)</td>
+    <td>vertical-align</td>
+    <td>super | sub | baseline | <span class="smallblock">LENGTH</span>  (mPDF >= 5.7.3)</td>
 </tr>
 <tr>
-<td>letter-spacing</td>
-<td>normal | <span class="smallblock">LENGTH</span>  (mPDF >= 5.1)</td>
+    <td>letter-spacing</td>
+    <td>normal | <span class="smallblock">LENGTH</span>  (mPDF >= 5.1)</td>
 </tr>
 <tr>
-<td>word-spacing</td>
-<td>normal | <span class="smallblock">LENGTH</span>  (mPDF >= 5.1)</td>
+    <td>word-spacing</td>
+    <td>normal | <span class="smallblock">LENGTH</span>  (mPDF >= 5.1)</td>
 </tr>
 <tr>
-<td>color</td>
-<td><span class="smallblock">COLOR</span></td>
+    <td>color</td>
+    <td><span class="smallblock">COLOR</span></td>
 </tr>
 <tr>
-<td>text-decoration</td>
-<td>
+    <td>text-decoration</td>
+<td markdown="1">
 
-underline | line-through | normal (line-through = strike-through)  (mPDF >= 5.4)
+underline \| line-through \| normal (line-through = strike-through)  (mPDF >= 5.4)
 
 overline  (mPDF >= 5.7.3)
 
 </td>
 </tr>
 <tr>
-<td>text-outline</td>
-<td>thickness [ blur ] color; OR none (default)
+    <td>text-outline</td>
+<td markdown="1">
+thickness [ blur ] color; OR none (default)
 
 Blur is not supported.
 
@@ -2023,66 +2017,63 @@ As per CSS3
 </td>
 </tr>
 <tr>
-<td>text-outline-width, *outline-width*</td>
-<td>Width of the outline. <span class="smallblock">LENGTH</span>
+<td markdown="1">
+text-outline-width, *outline-width*
+</td>
+<td markdown="1">
+Width of the outline. <span class="smallblock">LENGTH</span>
 
-(text-outline-width as from mPDF >= 5.7) Supported in tables >= 6.0</td>
-</tr>
-<tr>
-<td>text-outline-color, *outline-color*</td>
-<td><span class="smallblock">COLOR</span>  = colour of the inner part of the text e.g. #rrggbb. 'INVERT' is also accepted.
+(text-outline-width as from mPDF >= 5.7) 
 
-(text-outline-color as from mPDF >= 5.7) Supported in tables >= 6.0</td>
-</tr>
-<tr>
-<td>text-shadow</td>
-<td>
-
-As per CSS3 specification. 'blur' is not supported.  (mPDF >= 5.4)
-
+Supported in tables >= 6.0
 </td>
 </tr>
 <tr>
-<td>text-transform</td>
-<td><span class="smallblock"> </span>capitalize | uppercase | lowercase  (mPDF >= 5.4)</td>
+<td markdown="1">
+text-outline-color, *outline-color*
+</td>
+<td markdown="1">
+<span class="smallblock">COLOR</span>  = colour of the inner part of the text e.g. #rrggbb. 'INVERT' is also accepted.
+
+(text-outline-color as from mPDF >= 5.7) Supported in tables >= 6.0
+</td>
 </tr>
 <tr>
-<td>unicode-bidi</td>
-<td>
-
-normal | embed | isolate | bidi-override | isolate-override | plaintext
-
+    <td>text-shadow</td>
+    <td>As per CSS3 specification. 'blur' is not supported.  (mPDF >= 5.4)</td>
+</tr>
+<tr>
+    <td>text-transform</td>
+    <td><span class="smallblock"> </span>capitalize | uppercase | lowercase  (mPDF >= 5.4)</td>
+</tr>
+<tr>
+    <td>unicode-bidi</td>
+<td markdown="1">
+normal \| embed \| isolate \| bidi-override \| isolate-override \| plaintext
+ 
 (mPDF >= 6.0)
-
+ 
 When used on block-level elements:
-
 - the value is not inherited to child blocks
-
 - using "embed" or "isolate" has no effect on block level-boxes
-
 - "isolate-override" is equivalent to "bidi-override" on block-level boxes
-
 </td>
 </tr>
 </tbody> </table>
 
 **Notes:**
 
-* Margin, padding, border-width, border-color and border-style accept the various shorthand forms e.g.:
-
-margin:1pt; will set all top, right, bottom and left values the same
-
-margin:1pt 2pt; will set top and bottom to 1pt, left and right to 2pt
-
-margin:1pt 2pt 3pt; will set top to 1pt, left and right to 2pt, and bottom to 3pt (mPDF >= 4.0)
-
-margin:1pt 2pt 3pt 4pt; will set all values in order: top&gt;right&gt;bottom&gt;left
+*Margin, padding, border-width, border-color and border-style accept the various shorthand forms e.g.:
+ * margin:1pt; will set all top, right, bottom and left values the same
+ * margin:1pt 2pt; will set top and bottom to 1pt, left and right to 2pt
+ * margin:1pt 2pt 3pt; will set top to 1pt, left and right to 2pt, and bottom to 3pt (mPDF >= 4.0)
+ * margin:1pt 2pt 3pt 4pt; will set all values in order: top>right>bottom>left
 
 NB Table page-break-inside, autosize values and rotate are only respected for that set on first level table of nested tables
 
 ## Border
 
-medium|thin|thick are accepted for size - converted to 1px, 3px, 5px
+medium \| thin \| thick are accepted for size - converted to 1px, 3px, 5px
 
 # See Also
 


### PR DESCRIPTION
Adding in a html tags markdown="1" enables the markdown rendering again.
