### PR TITLE
some improvements

### DIFF
--- a/fonts-languages/automatic-font-selection.md
+++ b/fonts-languages/automatic-font-selection.md
@@ -12,11 +12,11 @@ modification_time: 2015-08-05T11:59:31+00:00
 
 mPDF has two functions which can be used together or separately:
 
- * <a href="{{ "/reference/mpdf-variables/autoscripttolang.html" | prepend: site.baseurl }}">`autoScriptToLang`</a> - marks up HTML text using the lang attribute, based on the Unicode script block in question,
-and values in `\Mpdf\ScriptToLang` class.
+ * <a href="{{ "/reference/mpdf-variables/autoscripttolang.html" | prepend: site.baseurl }}">`autoScriptToLang`</a> - marks 
+   up HTML text using the lang attribute, based on the Unicode script block in question, and values in `\Mpdf\ScriptToLang` class.
 
- * <a href="{{ "/reference/mpdf-variables/autolangtofont.html" | prepend: site.baseurl }}">`autoLangToFont`</a> - selects the font to use, based on the HTML lang attribute, using values from
-`\Mpdf\LangToFont` class.
+ * <a href="{{ "/reference/mpdf-variables/autolangtofont.html" | prepend: site.baseurl }}">`autoLangToFont`</a> - selects 
+   the font to use, based on the HTML lang attribute, using values from `\Mpdf\LangToFont` class.
 
 For automatic font selection, ideally we would choose the font based on the language in use. However it is actually
 impossible to determine the language used from a string of HTML text. The Unicode script block can be ascertained,
@@ -55,14 +55,15 @@ $mpdf->autoArabic = true;
 
 ```
 
-<a href="{{ "/reference/mpdf-variables/basescript.html" | prepend: site.baseurl }}">`baseScript`</a> tells mPDF which Script to ignore. It is set by default to `1` which is for Latin script.
-In this mode, all scripts *except* Latin script are marked up with `lang` attribute. To select other scripts as
-the base, see the `\Mpdf\Ucdn` class
+<a href="{{ "/reference/mpdf-variables/basescript.html" | prepend: site.baseurl }}">`baseScript`</a> tells mPDF which 
+Script to ignore. It is set by default to `1` which is for Latin script. In this mode, all scripts *except* Latin script 
+are marked up with `lang` attribute. To select other scripts as the base, see the `\Mpdf\Ucdn` class
 
-Using <a href="{{ "/reference/mpdf-variables/autoscripttolang.html" | prepend: site.baseurl }}">`autoScriptToLang`</a>, mPDF detects text runs based on Unicode script block; using the values in
-`\Mpdf\ScriptToLang` it then encloses the text run within a span tag with the appropriate language attribute.
-For many scripts, the language cannot be determined: see the example above which recognises Cyrillic script and
-marks it up using `und-Cyrl`, which is a valid IETF tag, coding for language="undetermined", script="Cyrillic".
+Using <a href="{{ "/reference/mpdf-variables/autoscripttolang.html" | prepend: site.baseurl }}">`autoScriptToLang`</a>, 
+mPDF detects text runs based on Unicode script block; using the values in `\Mpdf\ScriptToLang` it then encloses the 
+text run within a span tag with the appropriate language attribute. For many scripts, the language cannot be determined: 
+see the example above which recognises Cyrillic script and marks it up using `und-Cyrl`, which is a valid IETF tag, 
+coding for language="undetermined", script="Cyrillic".
 
 Two optional refinements are added: Vietnamese text can often be recognised by the presence of certain characters
 which do not appear in other Latin script languages, and similarly analysis of the text can attempt to distinguish
@@ -70,7 +71,8 @@ Arabic, Farsi, Pashto, Urdu and Sindhi. If active, the text will then be marked 
 `vi`, `pa`, `ur`, `fa` etc.
 
 These features can be disabled or enabled (default) using the 
-<a href="{{ "/reference/mpdf-variables/autoarabic.html" | prepend: site.baseurl }}">`autoArabic`</a> and <a href="{{ "/reference/mpdf-variables/autovietnamese.html" | prepend: site.baseurl }}">`autoVietnamese`</a> configuration variables.
+<a href="{{ "/reference/mpdf-variables/autoarabic.html" | prepend: site.baseurl }}">`autoArabic`</a> and 
+<a href="{{ "/reference/mpdf-variables/autovietnamese.html" | prepend: site.baseurl }}">`autoVietnamese`</a> configuration variables.
 
 # autoLangToFont
 

--- a/fonts-languages/bidirectional-rtl-text-v6-x.md
+++ b/fonts-languages/bidirectional-rtl-text-v6-x.md
@@ -36,14 +36,12 @@ Direction can be set for any HTML block elements e.g. `<div><p><table><ul>` etc 
 
 ```html
 <div style="direction: rtl;">
-
 ```
 
 or
 
 ```css
 div.right { direction: rtl; }
-
 ```
 
 Block-level direction *may* affect text alignment, and will also influence text reversal in

--- a/fonts-languages/choosing-a-configuration-v5-x.md
+++ b/fonts-languages/choosing-a-configuration-v5-x.md
@@ -120,6 +120,7 @@ $this->fonttrans = array(
 
 Indic languages always require special handling
 (cf. <a href="{{ "/fonts-languages/indic-fonts-v5-x.html" | prepend: site.baseurl }}">Indic fonts</a>).
+
 Other than this, whether you need to do anything special is determined by the choice of fonts you use in the document,
 and whether they contain the necessary characters to display your text. The DejaVu fonts distributed with mPDF will
 usually display most Western and Eastern European languages, Cyrillic text, Baltic languages, Turkish, and Greek.
@@ -131,17 +132,12 @@ There are a number of different ways to do this:
 
 1.  Write your HTML code to specify the exact fonts needed:
 
-    ```
-    เป็นมนุษย์สุดประเสริฐเลิศคุณค่า
-
-    仝娃阿哀愛挨姶
-
-    仝娃阿哀愛挨姶
-
-    البرادعی البرادعی
-
-    पहला पन्ना
-
+    ```php
+    <p style="font-family: Garuda">เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</p>
+    <p style="font-family: BIG5">仝娃阿哀愛挨姶</p>
+    <p style="font-family: sun-exta">仝娃阿哀愛挨姶</p>
+    <p style="font-family: 'XB Riyaz'">البرادعی البرادعی</p>
+    <p style="font-family: ind_hi_1_001">पहला पन्ना</p>
     ```
 
 2.  Use the `lang` attribute to define the language. This causes mPDF to use a font as specified in the
@@ -149,14 +145,11 @@ There are a number of different ways to do this:
     in the list defined as `$unifonts`, otherwise the first font specified in the `$unifonts` list will be selected.
 
 
-    ```
-    เป็นมนุษย์สุดประเสริฐเลิศคุณค่า
-
-    仝娃阿哀愛挨姶
-
-    البرادعی البرادعی
-
-    पहला पन्ना
+    ```php
+    <p lang="th">เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</p>
+    <p lang="zh-CN">仝娃阿哀愛挨姶</p>
+    <p lang="ar">البرادعی البرادعی</p>
+    <p lang="hi">पहला पन्ना</p>
     ```
 
 

--- a/fonts-languages/choosing-a-configuration-v5-x.md
+++ b/fonts-languages/choosing-a-configuration-v5-x.md
@@ -291,7 +291,7 @@ $mpdf = new mPDF('ru-x');     // behaves as though ('ru') called (Russian)
 
 # See Also
 
-- <a href="{{ "/reference/mpdf-functions/annotation.html" | prepend: site.baseurl }}">RTL & Bidirectional text</a>
+- <a href="{{ "/fonts-languages/arabic-rtl-text-v5-x.html" | prepend: site.baseurl }}">RTL & Bidirectional text</a>
 - <a href="{{ "/reference/mpdf-functions/setautofont.html" | prepend: site.baseurl }}">SetAutoFont()</a> - Automatically detect language in the input HTML text and use appropriate fonts
 
 There is a useful list of language/country codes at:

--- a/fonts-languages/choosing-a-configuration-v6-x.md
+++ b/fonts-languages/choosing-a-configuration-v6-x.md
@@ -90,7 +90,7 @@ the document by selecting the fontnames: `'chelvetica'`, `'ccourier'` and `'ctim
 
 ```php
 
-This paragraph will use core fonts
+<p style="font-family:chelvetica">This paragraph will use core fonts</p>
 
 
 ```
@@ -123,40 +123,30 @@ of font selection:
   <a href="{{ "/fonts-languages/opentype-layout-otl.html" | prepend: site.baseurl }}">OpenType layout (OTL)</a>
 
 The DejaVu fonts distributed with mPDF contain characters (glyphs) to display most Western and Eastern European
-languages, Cyrillic text, Baltic languages, Turkish, and Greek. Languages which usually need special consideration
-are: CJK (chinese - japanese - korean) languages, Indic languages, Vietnamese, Thai, and Arabic languages. With these,
-you need to tell mPDF to select a suitable font.
+languages, Cyrillic text, Baltic languages, Turkish, and Greek. 
+
+Languages which usually need special consideration are: CJK (chinese - japanese - korean) languages, Indic languages, 
+Vietnamese, Thai, and Arabic languages. With these, you need to tell mPDF to select a suitable font.
 
 There are several different methods to do this:
 
 1.  Write your HTML code to specify the exact fonts needed:
     
     ```php
-    
-    เป็นมนุษย์สุดประเสริฐเลิศคุณค่า
-    
-    仝娃阿哀愛挨姶
-    
-    仝娃阿哀愛挨姶
-    
-    البرادعی البرادعی
-    
-    
+    <p style="font-family: Garuda">เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</p>
+    <p style="font-family: BIG5">仝娃阿哀愛挨姶</p>
+    <p style="font-family: sun-exta">仝娃阿哀愛挨姶</p>
+    <p style="font-family: 'XB Riyaz'">البرادعی البرادعی</p>
+    <p style="font-family: ind_hi_1_001">पहला पन्ना</p>
     ```
     
 2.  Write your HTML code using the `lang` attribute to define the language. 
     
-    ```php
-    
-    เป็นมนุษย์สุดประเสริฐเลิศคุณค่า
-    
-    仝娃阿哀愛挨姶
-    
-    البرادعی البرادعی
-    
-    पहला पन्ना
-    
-    
+    ```php    
+    <p lang="th">เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</p>
+    <p lang="zh-CN">仝娃阿哀愛挨姶</p>
+    <p lang="ar">البرادعی البرادعی</p>
+    <p lang="hi">पहला पन्ना</p>
     ```
     
     This needs to be used in conjunction with either:

--- a/fonts-languages/choosing-a-configuration-v6-x.md
+++ b/fonts-languages/choosing-a-configuration-v6-x.md
@@ -198,5 +198,5 @@ It is possible to use method (4) together with (1), (2) or (3), to ensure that a
 
 # See Also
 
-- <a href="{{ "/reference/mpdf-functions/annotation.html" | prepend: site.baseurl }}">RTL & Bidirectional text</a>
+- <a href="{{ "/fonts-languages/bidirectional-rtl-text-v6-x.html" | prepend: site.baseurl }}">RTL & Bidirectional text</a>
 

--- a/fonts-languages/choosing-a-configuration-v7-x.md
+++ b/fonts-languages/choosing-a-configuration-v7-x.md
@@ -196,5 +196,5 @@ It is possible to use method (4) together with (1), (2) or (3), to ensure that a
 
 # See Also
 
-- <a href="{{ "/reference/mpdf-functions/annotation.html" | prepend: site.baseurl }}">RTL & Bidirectional text</a>
+- <a href="{{ "/fonts-languages/bidirectional-rtl-text-v6-x.html" | prepend: site.baseurl }}">RTL & Bidirectional text</a>
 

--- a/fonts-languages/choosing-a-configuration-v7-x.md
+++ b/fonts-languages/choosing-a-configuration-v7-x.md
@@ -135,7 +135,6 @@ There are several different methods to do this:
     <p style="font-family: BIG5">仝娃阿哀愛挨姶</p>
     <p style="font-family: sun-exta">仝娃阿哀愛挨姶</p>
     <p style="font-family: 'XB Riyaz'">البرادعی البرادعی</p>
-    <p style="font-family: ind_hi_1_001">पहला पन्ना</p>
     ```
 
 2.  Write your HTML code using the `lang` attribute to define the language. 

--- a/fonts-languages/choosing-a-configuration-v7-x.md
+++ b/fonts-languages/choosing-a-configuration-v7-x.md
@@ -51,7 +51,7 @@ $mpdf = new \Mpdf\Mpdf(['mode' => 'c']);
 
 ```
 
-Note: due to encoding conversion, mPDF changes mb_internal_encoding and mb_regex_encoding internally when core fonts
+Note: due to encoding conversion, mPDF changes `mb_internal_encoding()` and `mb_regex_encoding()` internally when core fonts
 are being used. To restore original values, call `$mpdf->cleanup()` when you are done with generating the PDF.
 
 # 2. Embedded Unicode fonts
@@ -79,7 +79,6 @@ configuration settings and force subsetting of all fonts e.g.
 
 ```php
 <?php
-
 $mpdf = new mPDF(['mode' => 's']);
 
 ```
@@ -91,8 +90,7 @@ the document by selecting the fontnames: `'chelvetica'`, `'ccourier'` and `'ctim
 
 ```php
 
-This paragraph will use core fonts
-
+<p style="font-family:chelvetica">This paragraph will use core fonts</p>
 
 ```
 
@@ -101,7 +99,6 @@ translation configuration key `fonttrans` e.g.:
 
 ```php
 <?php
-
 $this->fonttrans = array(
 	'arial' => 'chelvetica',
 	'helvetica' => 'chelvetica',
@@ -124,40 +121,30 @@ of font selection:
   <a href="{{ "/fonts-languages/opentype-layout-otl.html" | prepend: site.baseurl }}">OpenType layout (OTL)</a>
 
 The DejaVu fonts distributed with mPDF contain characters (glyphs) to display most Western and Eastern European
-languages, Cyrillic text, Baltic languages, Turkish, and Greek. Languages which usually need special consideration
-are: CJK (chinese - japanese - korean) languages, Indic languages, Vietnamese, Thai, and Arabic languages. With these,
-you need to tell mPDF to select a suitable font.
+languages, Cyrillic text, Baltic languages, Turkish, and Greek. 
+
+Languages which usually need special consideration are: CJK (chinese - japanese - korean) languages, Indic languages, 
+Vietnamese, Thai, and Arabic languages. With these, you need to tell mPDF to select a suitable font.
 
 There are several different methods to do this:
 
 1.  Write your HTML code to specify the exact fonts needed:
 
     ```php
-
-    เป็นมนุษย์สุดประเสริฐเลิศคุณค่า
-
-    仝娃阿哀愛挨姶
-
-    仝娃阿哀愛挨姶
-
-    البرادعی البرادعی
-
-
+    <p style="font-family: Garuda">เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</p>
+    <p style="font-family: BIG5">仝娃阿哀愛挨姶</p>
+    <p style="font-family: sun-exta">仝娃阿哀愛挨姶</p>
+    <p style="font-family: 'XB Riyaz'">البرادعی البرادعی</p>
+    <p style="font-family: ind_hi_1_001">पहला पन्ना</p>
     ```
 
 2.  Write your HTML code using the `lang` attribute to define the language. 
 
     ```php
-
-    เป็นมนุษย์สุดประเสริฐเลิศคุณค่า
-
-    仝娃阿哀愛挨姶
-
-    البرادعی البرادعی
-
-    पहला पन्ना
-
-
+    <p lang="th">เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</p>
+    <p lang="zh-CN">仝娃阿哀愛挨姶</p>
+    <p lang="ar">البرادعی البرادعی</p>
+    <p lang="hi">पहला पन्ना</p>
     ```
 
     This needs to be used in conjunction with either:
@@ -180,7 +167,7 @@ There are several different methods to do this:
     - CSS stylesheet using the `:lang` selector
 
 4.  Use <a href="{{ "/reference/mpdf-variables/usesubstitutions.html" | prepend: site.baseurl }}">$useSubstitutions</a>
-    to use character susbstitution. mPDF will inspect every character in the HTML code, and if the character is not
+    to use character substitution. mPDF will inspect every character in the HTML code, and if the character is not
     represented in the specified font, it will try to substitute it from one of the fonts defined in `backupSubsFont`
     configuration key.
 

--- a/fonts-languages/fonts-in-mpdf-7-x.md
+++ b/fonts-languages/fonts-in-mpdf-7-x.md
@@ -12,7 +12,8 @@ in Truetype format are also supported.
 
 # Easy to add new fonts
 
-- Add your font directory to `fontDir` configuration parameter or by calling `$mpdf->AddFontDirectory()` method
+- Add your font directory to `fontDir` configuration parameter or by calling
+  `$mpdf-><a href="{{ "/reference/mpdf-functions/addfontdirectory.html" | prepend: site.baseurl }}">AddFontDirectory()</a>` method
 - Define the font file details in the `fontData` parameter array
 - Access the font by specifying it in your HTML code as the CSS font-family
 - Specifying languages for the font by defining custom `Mpdf\Language\LanguageToFontInterface`
@@ -110,6 +111,7 @@ and you will refer to them in HTML/CSS as `frutiger`.
 
     ```
 
+
 # Full Unicode support
 
 The DejaVu fonts distributed with mPDF contain an extensive set of characters - see
@@ -180,7 +182,7 @@ other (mainly) ancient scripts - see
 coverage of free fonts</a> for full list.
 
 mPDF uses a different method to embed fonts in the PDF file if they include characters from SMP or SIP, because the
-characters cannot be represented by a 4 character hex code 0000-FFFF. This method is less eficient than the default
+characters cannot be represented by a 4 character hex code 0000-FFFF. This method is less efficient than the default
 method, and it can be suppressed by adding the font name to the configuration key `BMPonly` configuration key.
 
 Note that the DejaVu fonts  distributed with mPDF do contain a few characters in the SMP plane, but most users will

--- a/installation-setup/folders-for-temporary-files.md
+++ b/installation-setup/folders-for-temporary-files.md
@@ -6,7 +6,7 @@ permalink: /installation-setup/folders-for-temporary-files.html
 modification_time: 2017-03-14T11:59:24+00:00
 ---
 
-mPDF is pre-configured to use `<path to mpdf>/tmp/` as a directory to write temporary files
+mPDF is pre-configured to use `<path to mpdf>/tmp` as a directory to write temporary files
 (mainly for images). Write permissions must be set for read/write access for the tmp directory.
 
 As the default temp directory will be in vendor folder, is is advised to set custom temporary directory.

--- a/installation-setup/installation-v7-x.md
+++ b/installation-setup/installation-v7-x.md
@@ -28,7 +28,6 @@ require_once __DIR__ . '/vendor/autoload.php';
 $mpdf = new \Mpdf\Mpdf();
 $mpdf->WriteHTML('<h1>Hello world!</h1>');
 $mpdf->Output();
-
 ```
 
 All <a href="{{ "/reference/mpdf-variables/overview.html" | prepend: site.baseurl }}">configuration directives</a> can
@@ -40,11 +39,16 @@ be set by the `$config` parameter of the <a href="{{ "/reference/mpdf-functions/
 // Define a page using all default values except "L" for Landscape orientation
 $mpdf = new \Mpdf\Mpdf(['orientation' => 'L']);
 ...
-
 ```
 
-It is recommended to set custom temporary directory via `tempDir` configuration key.
-The directory must have write permissions (mode `775` is recommended).
+It is recommended to <a href="{{ "/installation-setup/folders-for-temporary-files.html" | prepend: site.baseurl }}">set custom temporary directory</a>
+via `tempDir` configuration key. The directory must have write permissions (mode `775` is recommended).
+
+```php
+<?php
+// Define a page using all default values except "L" for Landscape orientation
+$mpdf = new \Mpdf\Mpdf(['tempDir' => __DIR__ . '/custom/temp/dir/path']);
+```
 
 If you have problems, please read the section on
 <a href="{{ "/troubleshooting/known-issues.html" | prepend: site.baseurl }}">troubleshooting</a> in the manual.


### PR DESCRIPTION
fix urls
layouting
adding example
restore some `<p>`

I guess `<p style="font-family: ind_hi_1_001">पहला पन्ना</p>` is intentionally removed in 7.x version..