### PR TITLE
fonts-in-mpdf-7-x: note about lowercase font name

### DIFF
--- a/fonts-languages/fonts-in-mpdf-7-x.md
+++ b/fonts-languages/fonts-in-mpdf-7-x.md
@@ -27,7 +27,7 @@ and you will refer to them in HTML/CSS as `frutiger`.
 1.  Define the directory with the font via `fontDir` configuration key or add it after instantiation
     with `$mpdf->AddFontDirectory()` method
 
-2.  Define the font details in `fontdata` configuration variable
+2.  Define the font details in `fontdata` configuration variable - font name must be lowercase, i.e. `frutiger`.
 
     Example below shows how to maintain default fonts and their settings
 


### PR DESCRIPTION
Because of various conversions to lowercase it is necessary to have the configuration key also lowercase, otherwise the font won't load at all:

- https://github.com/mpdf/mpdf/blob/development/src/Mpdf.php#L3761
- https://github.com/mpdf/mpdf/blob/development/src/Mpdf.php#L3964
- https://github.com/mpdf/mpdf/blob/development/src/Mpdf.php#L10606

I'm not sure which conversion is responsible for this, nor whether it would be better to fix this in Mpdf (which is way beyond this workaround), nor if this docs note should be in other fonts-in-mpdf-* files as well...