### PR TITLE
Change "true" prefix in mode variable

### DIFF
--- a/fonts-languages/choosing-a-configuration-v7-x.md
+++ b/fonts-languages/choosing-a-configuration-v7-x.md
@@ -170,7 +170,7 @@ There are several different methods to do this:
     ```php
     <?php
     /* Set the base langage to Chinese */
-    $mpdf->baseScript = \Mpdf\Ucdn:SCRIPT_HAN;
+    $mpdf->baseScript = \Mpdf\Ucdn::SCRIPT_HAN;
     ```
 
     If you want to control the fonts used for fallback languages you'll need to extend the `Mpdf\Language\LanguageToFont` class and pass that class to the `languageToFont` configuration option when initializing mPDF (<a href="{{ "/fonts-languages/fonts-in-mpdf-7-x.html" | prepend: site.baseurl }}">see option 4 in the Fonts in mPDF 7.x page</a>).

--- a/reference/mpdf-variables/useadobecjk.md
+++ b/reference/mpdf-variables/useadobecjk.md
@@ -23,7 +23,7 @@ The precise effect it has on different languages/fonts is specified in the `\Mpd
   **Note:** This value can only be set as a configuration variable
 
   To change the value at runtime, you must use `$mpdf = new \Mpdf\Mpdf(['mode' => '-aCJK']);` to set as
-  `false` or `$mpdf = new \Mpdf\Mpdf(['mode' => '-aCJK']); `to set as
+  `false` or `$mpdf = new \Mpdf\Mpdf(['mode' => '+aCJK']); `to set as
   `true`
 </div>
 


### PR DESCRIPTION
Please confirm whether the mode variable should be `+aCJK` when set to `true`.