### PR TITLE
Warn users to not use the same location for temporary and for output files

### DIFF
--- a/installation-setup/folders-for-temporary-files.md
+++ b/installation-setup/folders-for-temporary-files.md
@@ -10,7 +10,8 @@ mPDF is pre-configured to use `<path to mpdf>/tmp` as a directory to write tempo
 (mainly for images and fonts).
 
 It is advised to set custom temporary directory as the default temporary directory is in composer `vendor` directory.
-Permissions must be set for read/write access for the specified path.
+Permissions must be set for read/write access for the specified path.  
+Make sure your custom temporary directory is not the same are your output directory.
 
 If you wish to use a different directory for temporary files, you should define `tempDir` key in constructor
 `$config` parameter.


### PR DESCRIPTION
Today I ran into the issue where the temporary directory was the same as the output directory.  
This is all fine while testing but after running for a while it can give some unexpected behaviour.

So that's why I would like to add this to the docs to make sure people will not run into this problem in the future.

Maybe it's even better to highlight this even more, so feel free to change the text and markup.

Thanks for this great package ❤️ 