### PR TITLE
Added optional `continue2pages` parameter to `SetDocTemplate` method

### DIFF
--- a/reference/mpdf-functions/setdoctemplate.md
+++ b/reference/mpdf-functions/setdoctemplate.md
@@ -19,7 +19,7 @@ void **SetDocTemplate** (
 
 Specify an external PDF file to use as a template. Each page of the external source PDF file will be used as a template
 for the corresponding page in your new document. If the current mPDF document has more pages than the external PDF
-source document, the last page will (optionally) continue to be used for any remaining pages.
+source document, the last page or last 2 pages will (optionally) continue to be used for any remaining pages.
 
 # Parameters
 
@@ -44,6 +44,22 @@ source document, the last page will (optionally) continue to be used for any rem
     <code>$mpdf->SetDocTemplate()</code> with no parameters.
   </div>
 
+<span class="parameter">$continue2pages</span>
+
+: **Values**: `1` \| `0` \| `true` \| `false`
+  
+  If `true` (or any positive value) it forces the last 2 pages of the source file to continue
+  to be used alternately as a template, if the current mPDF document contains more pages than the source file.
+  The source file should contain at least 2 pages to enable this functionality.
+  If this option is set to `true` (or any positive value) the `$continue` parameter will automatically be set to the same positive value.
+  
+  Default: `false`
+  
+  <div class="alert alert-info" role="alert" markdown="1">
+    **Note:** If you want to turn the template off, just use
+    <code>$mpdf->SetDocTemplate()</code> with no parameters.
+  </div>
+
 # Changelog
 
 <table class="table">
@@ -57,6 +73,10 @@ source document, the last page will (optionally) continue to be used for any rem
 <tr>
   <td>2.3</td>
   <td>Function was added.</td>
+</tr>
+<tr>
+  <td>8.*</td>
+  <td>$continue2pages parameter was added.</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Added optional `continue2pages` parameter to `SetDocTemplate` method, allowing a template to continue the last 2 pages alternately.

This option makes it possible to set a document template of (minimum) 2 pages, where the last 2 pages will continue to be used alternately as a template. This allows the creation of PDF's for booklets with a background where the left page of the booklet matches in the right page of the booklet.
For example, you can use a 2 paged PDF as a template, where page 1 is used for each left (odd) page of the booklet and page 2 is used for each right (even) page of the booklet.

Related to changes in pull request: https://github.com/mpdf/mpdf/pull/1485

Note that the changelog should be changed to the correct version number as soon as the correct version number is known