### PR TITLE
Fix page-break-avoid behaviour

### DIFF
--- a/css-stylesheets/supported-css.md
+++ b/css-stylesheets/supported-css.md
@@ -1211,9 +1211,10 @@ Unless otherwise stated, the following values are supported:
 <tr>
   <td>page-break-before, page-break-after</td>
   <td markdown="1">
-  avoid | allow
+  avoid \| allow
 
   Allows grouping of table rows and avoiding page breaks between two pages inside a group.
+  since 8.2.4
   </td>
 </tr>
 <tr>

--- a/css-stylesheets/supported-css.md
+++ b/css-stylesheets/supported-css.md
@@ -1111,7 +1111,7 @@ Unless otherwise stated, the following values are supported:
   <td>left | center | right</td>
 </tr>
 <tr>
-  <th rowspan="9">TR</th>
+  <th rowspan="10">TR</th>
   <td>background-color</td>
   <td><span class="smallblock">COLOR</span></td>
 </tr>
@@ -1206,6 +1206,14 @@ Unless otherwise stated, the following values are supported:
   odd \| even \| *a*n+*b*
 
   As per CSS3 specification
+  </td>
+</tr>
+<tr>
+  <td>page-break-before, page-break-after</td>
+  <td markdown="1">
+  avoid | allow
+
+  Allows grouping of table rows and avoiding page breaks between two pages inside a group.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
This is a repost. Last time, I implemented the page-break: avoid; behaviour in tables for mpdf (which got merged, that's fine) but I found a bug which i fix with this pull request:

When the page-break: avoid; block is too large for one page, mpdf used to spawn one <tr> per page, which is considered unwanted. This patch fixes this behaviour by detecting large page-break blocks and forcing a break at exactly the page limit.