### PR TITLE
Remove invalid syntax for `$mode` when using a country/language code

### DIFF
--- a/reference/mpdf-functions/construct.md
+++ b/reference/mpdf-functions/construct.md
@@ -57,7 +57,7 @@ Initialise an instance of mPDF class.
 
     Country/language codes are defined in `\Mpdf\LangToFont` class
 
-    A country/language code can be passed as e.g. `'en-GB'` or `'en_GB'` or `'en'`
+    A country/language code can be passed as `'en-GB'` or `'en'`, and should follow the [BCP 47 language tag format](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag). 
 
     <div class="alert alert-info" role="alert" markdown="1">
       **Note:** If the <span class="parameter">mode</span> is set by passing a country/language string,


### PR DESCRIPTION
The syntax `en_GB` is invalid for the `$mode`. Based on the PDF 1.6 specification, the format should follow RFC 3066 `en-GB` (the code is used in the `/Lang` entry). 

RFC 3066 has been revised multiple times, and looks to fall under the BCP 47 language tag standard now. The PR also adds a link to documentation on the BCP 47 language tag format.

**References**

* Page 865 of the PDF 1.6 Spec: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.6.pdf
* IETF language tag: https://en.wikipedia.org/wiki/IETF_language_tag
* RFC 3066: https://www.rfc-editor.org/rfc/rfc3066
* BCP 47: https://datatracker.ietf.org/doc/bcp47/
* Line 10 of mPDF's LanguageToFont class: https://github.com/mpdf/mpdf/blob/development/src/Language/LanguageToFont.php#L10
* Lines 333-337 of MetadataWriter: https://github.com/mpdf/mpdf/blob/development/src/Writer/MetadataWriter.php#L333-L337